### PR TITLE
add valueLimits to bookmarks

### DIFF
--- a/src/main/java/de/embl/cba/mobie/image/ImagePropertiesToMetadataAdapter.java
+++ b/src/main/java/de/embl/cba/mobie/image/ImagePropertiesToMetadataAdapter.java
@@ -16,6 +16,8 @@ public class ImagePropertiesToMetadataAdapter
 				? imageProperties.contrastLimits : metadata.contrastLimits;
 		metadata.color = imageProperties.color != null
 				? imageProperties.color : metadata.color;
+		metadata.valueLimits = imageProperties.valueLimits != null
+				? imageProperties.valueLimits : metadata.valueLimits;
 
 		if ( metadata.color != null )
 		{

--- a/src/main/java/de/embl/cba/mobie/image/MutableImageProperties.java
+++ b/src/main/java/de/embl/cba/mobie/image/MutableImageProperties.java
@@ -7,6 +7,7 @@ public class MutableImageProperties
 	public String color;
 	public String colorByColumn;
 	public double[] contrastLimits;
+	public double[] valueLimits;
 	public ArrayList< String > tables;
 	public ArrayList< Double > selectedLabelIds;
 	public boolean showSelectedSegmentsIn3d;

--- a/src/main/java/de/embl/cba/mobie/ui/viewer/SourcesPanel.java
+++ b/src/main/java/de/embl/cba/mobie/ui/viewer/SourcesPanel.java
@@ -420,16 +420,7 @@ public class SourcesPanel extends JPanel
     {
         if ( metadata.contrastLimits != null )
         {
-            if ( metadata.colorByColumn == null )
-            {
-                bdvStackSource.setDisplayRange( metadata.contrastLimits[ 0 ], metadata.contrastLimits[ 1 ] );
-            }
-            else
-            {
-                // TODO: This should be configurable
-                //   See issue: https://github.com/mobie/mobie-viewer-fiji/issues/127
-                bdvStackSource.setDisplayRange( 0, 1000 );
-            }
+            bdvStackSource.setDisplayRange( metadata.contrastLimits[ 0 ], metadata.contrastLimits[ 1 ] );
         }
     }
 
@@ -482,9 +473,6 @@ public class SourcesPanel extends JPanel
         configureSegments3dView( views, sam );
         configureTableView( views, sam );
 
-        // TODO: Kimberly: Here change the coloring model to what is specified in the Metadata, enable this.
-        // views.getTableRowsTableView().colorByColumn( sam.metadata().colorByColumn, sam.metadata().color );
-
         bdv = views.getSegmentsBdvView().getBdv();
 
         sam.metadata().bdvStackSource = views
@@ -529,11 +517,19 @@ public class SourcesPanel extends JPanel
         // apply colorByColumn
         if ( sam.metadata().colorByColumn != null && sam.metadata().color != null )
         {
-            views.getTableRowsTableView().colorByColumn(
+            if ( sam.metadata().valueLimits != null ) {
+                views.getTableRowsTableView().colorByColumn(
                         sam.metadata().colorByColumn,
                         sam.metadata().color,
-                        sam.metadata().contrastLimits[ 0 ],
-                        sam.metadata().contrastLimits[ 1 ] );
+                        sam.metadata().valueLimits[0],
+                        sam.metadata().valueLimits[1]);
+            } else {
+                views.getTableRowsTableView().colorByColumn(
+                        sam.metadata().colorByColumn,
+                        sam.metadata().color,
+                        null,
+                        null);
+            }
         }
 
     }


### PR DESCRIPTION
Add valueLimits to bookmarks. 
This now means that 'contrastLimits' is used for the brightness of the segmentation, and 'valueLimits' for the specific limits for colorByColumn. If no valueLimits are supplied, it uses the min/max of the specified column (same as default for colouring by column from the table menu)

For issue: https://github.com/mobie/mobie-viewer-fiji/issues/127