### PR TITLE
Bookmark ui

### DIFF
--- a/src/main/java/de/embl/cba/mobie/bookmark/BookmarkGithubWriter.java
+++ b/src/main/java/de/embl/cba/mobie/bookmark/BookmarkGithubWriter.java
@@ -1,0 +1,134 @@
+package de.embl.cba.mobie.bookmark;
+
+import com.google.gson.GsonBuilder;
+import com.google.gson.internal.LinkedTreeMap;
+import de.embl.cba.tables.FileAndUrlUtils;
+import de.embl.cba.tables.FileUtils;
+import de.embl.cba.tables.github.GitHubContentGetter;
+import de.embl.cba.tables.github.GitHubFileCommitter;
+import de.embl.cba.tables.github.GitLocation;
+import ij.Prefs;
+import ij.gui.GenericDialog;
+import org.apache.commons.compress.utils.FileNameUtils;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+public class BookmarkGithubWriter {
+
+    public static final String ACCESS_TOKEN = "MoBIE.GitHub access token";
+    private String accessToken;
+    private String bookmarkFileName;
+    private GitLocation bookmarkGitLocation;
+    private BookmarksJsonParser bookmarksJsonParser;
+
+    BookmarkGithubWriter(GitLocation bookmarkGitLocation, BookmarksJsonParser bookmarksJsonParser) {
+        this.bookmarkGitLocation = bookmarkGitLocation;
+        this.bookmarksJsonParser = bookmarksJsonParser;
+    }
+
+    //repository
+    //branch
+    //dataset
+
+    private ArrayList< String > getFilePaths()
+    {
+        final GitHubContentGetter contentGetter =
+                new GitHubContentGetter( bookmarkGitLocation.repoUrl, bookmarkGitLocation.path, bookmarkGitLocation.branch, null );
+        final String json = contentGetter.getContent();
+
+        GsonBuilder builder = new GsonBuilder();
+
+        final ArrayList< String > bookmarkPaths = new ArrayList<>();
+        ArrayList<LinkedTreeMap> linkedTreeMaps = ( ArrayList< LinkedTreeMap >) builder.create().fromJson( json, Object.class );
+        for ( LinkedTreeMap linkedTreeMap : linkedTreeMaps )
+        {
+            final String downloadUrl = ( String ) linkedTreeMap.get( "download_url" );
+            bookmarkPaths.add( downloadUrl );
+        }
+        return bookmarkPaths;
+    }
+
+    private ArrayList<String> getBookmarkFileNamesFromPaths (ArrayList<String> bookmarkPaths) {
+        ArrayList<String> bookmarkNames = new ArrayList<>();
+        for (String path : bookmarkPaths) {
+            bookmarkNames.add(FileNameUtils.getBaseName(path));
+        }
+        return bookmarkNames;
+    }
+
+    private String getMatchingBookmarkFilePath () {
+        ArrayList<String> bookmarkFilesOnGithub = getFilePaths();
+        ArrayList<String> bookmarkFileNames = getBookmarkFileNamesFromPaths(bookmarkFilesOnGithub);
+        for (int i=0; i<bookmarkFileNames.size(); i++) {
+            if (bookmarkFileNames.get(i) == bookmarkFileName) {
+                return bookmarkFilesOnGithub.get(i);
+            }
+        }
+
+        return null;
+    }
+
+    private String constructBookmarkPath () {
+        // FileAndUrlUtils.combinePath(bookmarkGitLocation.repoUrl + "/misc/bookmarks");
+        return "no";
+    }
+
+    private Map<String, Bookmark> appendBookmarkToExistingFile (String githubFilePath, Bookmark bookmark, String bookmarkName) {
+        ArrayList<String> bookmarkPaths = new ArrayList<>();
+        bookmarkPaths.add(githubFilePath);
+        Map<String, Bookmark> bookmarksInFile = new HashMap<>();
+        try {
+            Map<String, Bookmark> existingBookmarks = bookmarksJsonParser.parseBookmarks(bookmarkPaths);
+            bookmarksInFile.putAll(existingBookmarks);
+            bookmarksInFile.put(bookmarkName, bookmark);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return bookmarksInFile;
+    }
+
+    public void writeBookmarkToGithub(Bookmark bookmark) {
+        if (showDialog()) {
+            // String matchingBookmarkFilePathFromGithub = getMatchingBookmarkFilePath();
+            Bookmark bookmarkToWrite = bookmark;
+
+            Map<String, Bookmark> bookmarksInFile = new HashMap<>();
+            bookmarksInFile.put(bookmark.name, bookmark);
+
+            final String bookmarkJsonBase64String = bookmarksJsonParser.writeBookmarksToBase64String(bookmarksInFile);
+            final GitHubFileCommitter fileCommitter = new GitHubFileCommitter(
+                    bookmarkGitLocation.repoUrl, accessToken, bookmarkGitLocation.path + bookmarkFileName + ".json"
+            );
+            fileCommitter.commitStringAsFile("test bookmark file", bookmarkJsonBase64String);
+
+            // if (matchingBookmarkFilePathFromGithub != null){
+            //
+            // } else {
+            //     //write
+            // }
+        }
+    }
+
+    private boolean showDialog()
+    {
+        final GenericDialog gd = new GenericDialog( "Save to github" );
+        final int columns = 80;
+
+        gd.addStringField( "GitHub access token", Prefs.get( ACCESS_TOKEN, "1234567890" ), columns );
+        gd.addStringField( "Bookmark file name", "", columns );
+        gd.showDialog();
+
+        if ( gd.wasCanceled() ) return false;
+
+        accessToken = gd.getNextString();
+        bookmarkFileName = gd.getNextString();
+
+        Prefs.set( ACCESS_TOKEN, accessToken );
+
+        return true;
+    }
+}

--- a/src/main/java/de/embl/cba/mobie/bookmark/BookmarkGithubWriter.java
+++ b/src/main/java/de/embl/cba/mobie/bookmark/BookmarkGithubWriter.java
@@ -55,16 +55,21 @@ public class BookmarkGithubWriter {
         return bookmarkNamesToPaths;
     }
 
-    private ArrayList<String> getMatchingBookmarkFilePathAndSha () {
+    class FilePathAndSha {
+        String filePath;
+        String sha;
+    }
+
+    private FilePathAndSha getMatchingBookmarkFilePathAndSha () {
         Map<String, String> bookmarkPathsToSha = getFilePathsToSha();
         Map<String, String> bookmarkFileNamesToPaths = getBookmarkFileNamesToPaths(bookmarkPathsToSha.keySet());
 
         for (String bookmarkFileNameGithub : bookmarkFileNamesToPaths.keySet()) {
             if (bookmarkFileNameGithub.equals(bookmarkFileName)) {
-                ArrayList<String> matchingFileAndSha = new ArrayList<>();
+                FilePathAndSha matchingFileAndSha = new FilePathAndSha();
                 String matchingPath = bookmarkFileNamesToPaths.get(bookmarkFileNameGithub);
-                matchingFileAndSha.add(matchingPath);
-                matchingFileAndSha.add(bookmarkPathsToSha.get(matchingPath));
+                matchingFileAndSha.filePath = matchingPath;
+                matchingFileAndSha.sha = bookmarkPathsToSha.get(matchingPath);
                 return matchingFileAndSha;
             }
         }
@@ -81,7 +86,7 @@ public class BookmarkGithubWriter {
                 }
 
                 // check for matching bookmark file on github
-                ArrayList<String> matchingFilePathAndSha = getMatchingBookmarkFilePathAndSha();
+                FilePathAndSha matchingFilePathAndSha = getMatchingBookmarkFilePathAndSha();
 
                 boolean appendToFile = false;
                 if (matchingFilePathAndSha != null) {
@@ -95,7 +100,7 @@ public class BookmarkGithubWriter {
 
                     if (appendToFile) {
                         ArrayList<String> matchingFilePathsFromGithub = new ArrayList<>();
-                        matchingFilePathsFromGithub.add(matchingFilePathAndSha.get(0));
+                        matchingFilePathsFromGithub.add(matchingFilePathAndSha.filePath);
                         Map<String, Bookmark> existingBookmarks = bookmarksJsonParser.parseBookmarks(matchingFilePathsFromGithub);
                         bookmarksInFile.putAll(existingBookmarks);
                     }
@@ -107,7 +112,7 @@ public class BookmarkGithubWriter {
                     if (appendToFile) {
                         fileCommitter = new GitHubFileCommitter(
                                 bookmarkGitLocation.repoUrl, accessToken, bookmarkGitLocation.branch,
-                                bookmarkGitLocation.path + "/" + bookmarkFileName + ".json", matchingFilePathAndSha.get(1));
+                                bookmarkGitLocation.path + "/" + bookmarkFileName + ".json", matchingFilePathAndSha.sha);
                     } else {
                         fileCommitter = new GitHubFileCommitter(
                                 bookmarkGitLocation.repoUrl, accessToken, bookmarkGitLocation.branch,

--- a/src/main/java/de/embl/cba/mobie/bookmark/BookmarksJsonParser.java
+++ b/src/main/java/de/embl/cba/mobie/bookmark/BookmarksJsonParser.java
@@ -48,8 +48,13 @@ public class BookmarksJsonParser {
 		try {
 			ArrayList<String> filePaths = new ArrayList<>();
 			String bookmarksDirectory = FileAndUrlUtils.combinePath(datasetLocation, "misc", "bookmarks");
-			filePaths.add( selectPathFromProjectOrFileSystem( bookmarksDirectory, "Bookmark" ) );
-			return parseBookmarks(filePaths);
+			String selectedFilePath = selectPathFromProjectOrFileSystem( bookmarksDirectory, "Bookmark" );
+			if (selectedFilePath != null) {
+				filePaths.add(selectedFilePath);
+				return parseBookmarks(filePaths);
+			} else {
+				return null;
+			}
 		} catch (IOException e) {
 			e.printStackTrace();
 			return null;

--- a/src/main/java/de/embl/cba/mobie/bookmark/BookmarksJsonParser.java
+++ b/src/main/java/de/embl/cba/mobie/bookmark/BookmarksJsonParser.java
@@ -5,6 +5,7 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.internal.LinkedTreeMap;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 import de.embl.cba.tables.github.GitHubUtils;
 import de.embl.cba.tables.github.GitLocation;
 import de.embl.cba.mobie.image.SourcesModel;
@@ -14,10 +15,7 @@ import de.embl.cba.tables.github.GitHubContentGetter;
 import de.embl.cba.tables.github.GitHubUtils;
 import de.embl.cba.tables.github.GitLocation;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.io.*;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
@@ -143,6 +141,17 @@ public class BookmarksJsonParser
 		reader.close();
 		inputStream.close();
 		return stringBookmarkMap;
+	}
+
+	public void writeBookmarksToFile (String filePath, Map< String, Bookmark > bookmarks) throws IOException {
+		Gson gson = new Gson();
+		Type type = new TypeToken< Map< String, Bookmark > >() {}.getType();
+
+		OutputStream outputStream = new FileOutputStream( new File( filePath ) );
+		final JsonWriter writer = new JsonWriter( new OutputStreamWriter(outputStream, "UTF-8"));
+		gson.toJson(bookmarks, type, writer);
+		writer.close();
+		outputStream.close();
 	}
 
 	private ArrayList< String > fetchBookmarkPaths()

--- a/src/main/java/de/embl/cba/mobie/bookmark/BookmarksJsonParser.java
+++ b/src/main/java/de/embl/cba/mobie/bookmark/BookmarksJsonParser.java
@@ -1,5 +1,7 @@
 package de.embl.cba.mobie.bookmark;
 
+import com.google.gson.ExclusionStrategy;
+import com.google.gson.FieldAttributes;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.internal.LinkedTreeMap;
@@ -144,11 +146,31 @@ public class BookmarksJsonParser
 	}
 
 	public void writeBookmarksToFile (String filePath, Map< String, Bookmark > bookmarks) throws IOException {
-		Gson gson = new Gson();
+//		Gson gson = new GsonBuilder().setPrettyPrinting().create();
+
+		// exclude the name field
+		ExclusionStrategy strategy = new ExclusionStrategy() {
+			@Override
+			public boolean shouldSkipField(FieldAttributes f) {
+				if (f.getName().equals("name")) {
+					return true;
+				}
+				return false;
+			}
+
+			@Override
+			public boolean shouldSkipClass(Class<?> clazz) {
+				return false;
+			}
+		};
+
+		Gson gson = new GsonBuilder().addSerializationExclusionStrategy(strategy).create();
 		Type type = new TypeToken< Map< String, Bookmark > >() {}.getType();
 
 		OutputStream outputStream = new FileOutputStream( new File( filePath ) );
 		final JsonWriter writer = new JsonWriter( new OutputStreamWriter(outputStream, "UTF-8"));
+		writer.setIndent("	");
+//		gson.toJson(bookmarks, writer);
 		gson.toJson(bookmarks, type, writer);
 		writer.close();
 		outputStream.close();

--- a/src/main/java/de/embl/cba/mobie/bookmark/BookmarksJsonParser.java
+++ b/src/main/java/de/embl/cba/mobie/bookmark/BookmarksJsonParser.java
@@ -98,7 +98,7 @@ public class BookmarksJsonParser {
 		bookmarkWriter.writeBookmarksToGithub(bookmarks);
 	}
 
-	private Gson createBookmarkWriterGson (boolean usePrettyPrinting) {
+	private Gson createGsonBuilder(boolean usePrettyPrinting) {
 		// exclude the name field from json
 		ExclusionStrategy strategy = new ExclusionStrategy() {
 			@Override
@@ -158,7 +158,7 @@ public class BookmarksJsonParser {
 
 			if (jsonFile != null) {
 
-				Gson gson = createBookmarkWriterGson(false);
+				Gson gson = createGsonBuilder(false);
 				Type type = new TypeToken<Map<String, Bookmark>>() {
 				}.getType();
 
@@ -208,7 +208,7 @@ public class BookmarksJsonParser {
 	}
 
 	public String writeBookmarksToBase64String (Map<String, Bookmark> bookmarks) {
-		Gson gson = createBookmarkWriterGson(true);
+		Gson gson = createGsonBuilder(true);
 		Type type = new TypeToken<Map<String, Bookmark>>() {
 		}.getType();
 		String jsonString = gson.toJson(bookmarks, type);

--- a/src/main/java/de/embl/cba/mobie/bookmark/BookmarksJsonParser.java
+++ b/src/main/java/de/embl/cba/mobie/bookmark/BookmarksJsonParser.java
@@ -8,6 +8,7 @@ import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import de.embl.cba.tables.FileAndUrlUtils;
+import de.embl.cba.tables.FileUtils;
 
 import javax.swing.*;
 import javax.swing.filechooser.FileNameExtensionFilter;
@@ -22,6 +23,10 @@ public class BookmarksJsonParser {
 
 	public BookmarksJsonParser(String datasetLocation) {
 		this.datasetLocation = datasetLocation;
+	}
+
+	public String getDatasetLocation() {
+		return datasetLocation;
 	}
 
 	public Map<String, Bookmark> getDefaultBookmarks() {
@@ -77,14 +82,20 @@ public class BookmarksJsonParser {
 		return nameToBookmark;
 	}
 
-	public void saveBookmarks(ArrayList<Bookmark> bookmarks) throws IOException {
+	public void saveBookmarks(ArrayList<Bookmark> bookmarks, String fileLocation) throws IOException {
 		HashMap<String, Bookmark> namesToBookmarks = new HashMap<>();
 		for (Bookmark bookmark : bookmarks) {
 			namesToBookmarks.put(bookmark.name, bookmark);
 		}
 
 		String jsonPath = null;
-		final JFileChooser jFileChooser = new JFileChooser();
+		final JFileChooser jFileChooser;
+		if (fileLocation == FileUtils.FILE_SYSTEM) {
+			jFileChooser = new JFileChooser();
+		} else {
+			String bookmarksDirectory = FileAndUrlUtils.combinePath(datasetLocation + "/misc/bookmarks");
+			jFileChooser = new JFileChooser(bookmarksDirectory);
+		}
 		jFileChooser.setFileFilter(new FileNameExtensionFilter("json", "json"));
 		if (jFileChooser.showSaveDialog(null) == JFileChooser.APPROVE_OPTION) {
 			jsonPath = jFileChooser.getSelectedFile().getAbsolutePath();

--- a/src/main/java/de/embl/cba/mobie/bookmark/BookmarksJsonParser.java
+++ b/src/main/java/de/embl/cba/mobie/bookmark/BookmarksJsonParser.java
@@ -91,9 +91,6 @@ public class BookmarksJsonParser {
 
 		BookmarkGithubWriter bookmarkWriter = new BookmarkGithubWriter(gitLocation, this);
 		bookmarkWriter.writeBookmarksToGithub(bookmarks);
-		// check if file exists
-		// if it does, read it, append, then overwrite
-		// else just write
 	}
 
 	private Gson createBookmarkWriterGson (boolean usePrettyPrinting) {
@@ -149,11 +146,7 @@ public class BookmarksJsonParser {
 
 			File jsonFile = new File(jsonPath);
 			if (jsonFile.exists()) {
-				int result = JOptionPane.showConfirmDialog(null,
-						"This Json file already exists - append bookmark to this file?", "Append to file?",
-						JOptionPane.YES_NO_OPTION,
-						JOptionPane.QUESTION_MESSAGE);
-				if (result != JOptionPane.YES_OPTION) {
+				if (!appendToFileDialog()) {
 					jsonFile = null;
 				}
 			}
@@ -168,6 +161,18 @@ public class BookmarksJsonParser {
 			}
 		}
 
+	}
+
+	public boolean appendToFileDialog () {
+		int result = JOptionPane.showConfirmDialog(null,
+				"This Json file already exists - append bookmark to this file?", "Append to file?",
+				JOptionPane.YES_NO_OPTION,
+				JOptionPane.QUESTION_MESSAGE);
+		if (result != JOptionPane.YES_OPTION) {
+			return false;
+		} else {
+			return true;
+		}
 	}
 
 	private Map< String, Bookmark > readBookmarksFromFile( Gson gson, Type type, String bookmarksLocation ) throws IOException
@@ -203,8 +208,7 @@ public class BookmarksJsonParser {
 		}.getType();
 		String jsonString = gson.toJson(bookmarks, type);
 		byte[] jsonBytes = jsonString.getBytes(StandardCharsets.UTF_8);
-		byte[] encodedBytes = Base64.getEncoder().encode(jsonBytes);
-		return new String(encodedBytes);
+		return Base64.getEncoder().encodeToString(jsonBytes);
 		// TODO - add new line at end?
 	}
 }

--- a/src/main/java/de/embl/cba/mobie/bookmark/BookmarksJsonParser.java
+++ b/src/main/java/de/embl/cba/mobie/bookmark/BookmarksJsonParser.java
@@ -214,7 +214,7 @@ public class BookmarksJsonParser
 		OutputStream outputStream = new FileOutputStream( jsonFile );
 		final JsonWriter writer = new JsonWriter( new OutputStreamWriter(outputStream, "UTF-8"));
 		writer.setIndent("	");
-		gson.toJson(bookmarks, type, writer);
+		gson.toJson(bookmarksInFile, type, writer);
 		writer.close();
 		outputStream.close();
 	}

--- a/src/main/java/de/embl/cba/mobie/bookmark/BookmarksJsonParser.java
+++ b/src/main/java/de/embl/cba/mobie/bookmark/BookmarksJsonParser.java
@@ -32,11 +32,15 @@ public class BookmarksJsonParser
 		this.datasetLocation = datasetLocation;
 	}
 
-	public Map< String, Bookmark > getBookmarks()
+	public Map<String, Bookmark> getDefaultBookmarks() {
+		return getBookmarksFromFile("default");
+	}
+
+	public Map< String, Bookmark > getBookmarksFromFile(String fileName)
 	{
 		try
 		{
-			return readBookmarks();
+			return readBookmarks(String fileName);
 		}
 		catch ( IOException e )
 		{
@@ -98,9 +102,10 @@ public class BookmarksJsonParser
 		return bookmarkPaths;
 	}
 
-	private Map< String, Bookmark > readBookmarks() throws IOException
+	private Map< String, Bookmark > readBookmarks(String fileName) throws IOException
 	{
-		final ArrayList< String > bookmarkFiles = fetchBookmarkPaths();
+		ArrayList<String> bookmarkFiles = new ArrayList<>();
+		bookmarkFiles.add( fetchBookmarkPath(fileName) );
 		final Map< String, Bookmark > nameToBookmark = parseBookmarks( bookmarkFiles );
 		return nameToBookmark;
 	}
@@ -219,21 +224,21 @@ public class BookmarksJsonParser
 		outputStream.close();
 	}
 
-	private ArrayList< String > fetchBookmarkPaths()
+	private ArrayList< String > fetchBookmarkPath()
 	{
 		try
 		{
-			return fetchBookmarkPaths( datasetLocation );
+			return fetchBookmarkPath( datasetLocation );
 		}
 		catch ( Exception e )
 		{
 			if ( datasetLocation.contains( "githubusercontent" ) )
 			{
-				return addBookmarkFilesFromGithub( datasetLocation );
+				return addBookmarkFileFromGithub( datasetLocation );
 			}
 			else
 			{
-				return addBookmarkFilesFromFolder( datasetLocation );
+				return addBookmarkFileFromFolder( datasetLocation );
 			}
 		}
 	}

--- a/src/main/java/de/embl/cba/mobie/bookmark/BookmarksManager.java
+++ b/src/main/java/de/embl/cba/mobie/bookmark/BookmarksManager.java
@@ -106,7 +106,7 @@ public class BookmarksManager
 		ArrayList<Bookmark> bookmarks = new ArrayList<>();
 		bookmarks.add(currentBookmark);
 
-		if (bookmarkNameAndLocation.get(1) == FileUtils.PROJECT &&
+		if (bookmarkNameAndLocation.get(1).equals(FileUtils.PROJECT) &&
 				bookmarksJsonParser.getDatasetLocation().contains( "raw.githubusercontent" )) {
 			bookmarksJsonParser.saveBookmarksToGithub(bookmarks);
 		} else {
@@ -128,8 +128,6 @@ public class BookmarksManager
 		if ( gd.wasCanceled() ) return null;
 		bookmarkName = gd.getNextString();
 		fileLocation = gd.getNextChoice();
-		System.out.println(bookmarkName);
-		System.out.println(fileLocation);
 
 		ArrayList<String> bookmarkNameandLocation = new ArrayList<>();
 		bookmarkNameandLocation.add(bookmarkName);
@@ -150,7 +148,6 @@ public class BookmarksManager
 		Bookmark currentBookmark = new Bookmark();
 		currentBookmark.name = bookmarkName;
 		currentBookmark.layers = layers;
-		// TODO - add to bdv utils
 		double[] currentPosition = new double[3];
 		BdvUtils.getGlobalMouseCoordinates(bdv).localize(currentPosition);
 		currentBookmark.position = currentPosition;

--- a/src/main/java/de/embl/cba/mobie/bookmark/BookmarksManager.java
+++ b/src/main/java/de/embl/cba/mobie/bookmark/BookmarksManager.java
@@ -8,6 +8,7 @@ import de.embl.cba.mobie.image.MutableImageProperties;
 import de.embl.cba.mobie.ui.viewer.SourcesPanel;
 import de.embl.cba.mobie.bdv.BdvViewChanger;
 import de.embl.cba.mobie.utils.Utils;
+import de.embl.cba.tables.image.SourceAndMetadata;
 
 import javax.swing.*;
 import java.io.IOException;
@@ -56,18 +57,22 @@ public class BookmarksManager
 			final String sourceName = entry.getKey();
 			if ( ! sourcesPanel.getVisibleSourceNames().contains( sourceName ) )
 			{
-				final Metadata metadata = getAndUpdateSourceMetadata( entry, sourceName );
-				sourcesPanel.addSourceToPanelAndViewer( metadata.displayName );
+				final SourceAndMetadata< ? > samDefault = sourcesPanel.getSourceAndDefaultMetadata( sourceName );
+				final SourceAndMetadata< ? > samBookmark = new SourceAndMetadata(samDefault.source(), samDefault.metadata().copy());
+				updateSourceMetadata(entry, samBookmark.metadata());
+
+				// final Metadata metadata = getAndUpdateSourceMetadata( entry, sourceName );
+				// new SourceAndMetadata<>()
+				sourcesPanel.addSourceToPanelAndViewer( samBookmark );
 			}
 		}
 	}
 
-	public Metadata getAndUpdateSourceMetadata( Map.Entry< String, MutableImageProperties > entry, String sourceName )
+	public void updateSourceMetadata( Map.Entry< String, MutableImageProperties > entry, Metadata sourceMetadata )
 	{
-		final Metadata metadata = sourcesPanel.getImageSourcesModel().sources().get( sourceName ).metadata();
+		// final Metadata metadata = sourcesPanel.getImageSourcesModel().sources().get( sourceName ).metadata();
 		final ImagePropertiesToMetadataAdapter adapter = new ImagePropertiesToMetadataAdapter();
-		adapter.setMetadata( metadata, entry.getValue() );
-		return metadata;
+		adapter.setMetadata( sourceMetadata, entry.getValue() );
 	}
 
 	public void adaptViewerTransform( Bookmark bookmark )
@@ -108,7 +113,7 @@ public class BookmarksManager
 		Set<String> visibleSourceNames = sourcesPanel.getVisibleSourceNames();
 
 		for (String sourceName : visibleSourceNames) {
-			MutableImageProperties sourceImageProperties = sourcesPanel.getCurrentMutableImageProperties(sourceName);
+			MutableImageProperties sourceImageProperties = sourcesPanel.getCurrentImageProperties(sourceName);
 			layers.put(sourceName, sourceImageProperties);
 		}
 

--- a/src/main/java/de/embl/cba/mobie/bookmark/BookmarksManager.java
+++ b/src/main/java/de/embl/cba/mobie/bookmark/BookmarksManager.java
@@ -11,20 +11,15 @@ import de.embl.cba.mobie.utils.Utils;
 import de.embl.cba.tables.FileUtils;
 import de.embl.cba.tables.image.SourceAndMetadata;
 import de.embl.cba.tables.tablerow.TableRowImageSegment;
-import de.embl.cba.tables.view.Segments3dView;
 import de.embl.cba.tables.view.TableRowsTableView;
-import de.embl.cba.tables.view.combined.SegmentsTableBdvAnd3dViews;
 import ij.gui.GenericDialog;
 import net.imglib2.type.numeric.ARGBType;
 
 import javax.swing.*;
-import java.awt.*;
 import java.io.IOException;
-import java.net.URI;
 import java.util.*;
 
 import static de.embl.cba.mobie.ui.viewer.SourcesDisplayUI.getConverterSetups;
-import static de.embl.cba.tables.github.GitHubUtils.selectGitHubPathFromDirectory;
 
 public class BookmarksManager
 {
@@ -108,15 +103,15 @@ public class BookmarksManager
 	public void saveCurrentSettingsAsBookmark () {
 		ArrayList<String> bookmarkNameAndLocation = bookmarkSaveDialog();
 		Bookmark currentBookmark = getBookmarkFromCurrentSettings(bookmarkNameAndLocation.get(0));
+		ArrayList<Bookmark> bookmarks = new ArrayList<>();
+		bookmarks.add(currentBookmark);
 
 		if (bookmarkNameAndLocation.get(1) == FileUtils.PROJECT &&
 				bookmarksJsonParser.getDatasetLocation().contains( "raw.githubusercontent" )) {
-
+			bookmarksJsonParser.saveBookmarkToGithub(currentBookmark);
 		} else {
-			ArrayList<Bookmark> bookmarks = new ArrayList<>();
-			bookmarks.add(currentBookmark);
 			try {
-				bookmarksJsonParser.saveBookmarks(bookmarks, bookmarkNameAndLocation.get(1));
+				bookmarksJsonParser.saveBookmarksToFile(bookmarks, bookmarkNameAndLocation.get(1));
 			} catch (IOException e) {
 				e.printStackTrace();
 			}

--- a/src/main/java/de/embl/cba/mobie/bookmark/BookmarksManager.java
+++ b/src/main/java/de/embl/cba/mobie/bookmark/BookmarksManager.java
@@ -9,6 +9,7 @@ import de.embl.cba.mobie.image.MutableImageProperties;
 import de.embl.cba.mobie.ui.viewer.SourcesPanel;
 import de.embl.cba.mobie.bdv.BdvViewChanger;
 import de.embl.cba.mobie.utils.Utils;
+import ij.gui.GenericDialog;
 
 import java.io.IOException;
 import java.util.*;
@@ -18,6 +19,8 @@ public class BookmarksManager
 	private final SourcesPanel sourcesPanel;
 	private Map< String, Bookmark > nameToBookmark;
 	private BookmarksJsonParser bookmarksJsonParser;
+	private String PROJECT = "Project";
+	private String FILE_SYSTEM = "File system";
 
 	public BookmarksManager( SourcesPanel sourcesPanel, Map< String, Bookmark > nameToBookmark,
 							 BookmarksJsonParser bookmarksJsonParser )
@@ -76,6 +79,40 @@ public class BookmarksManager
 			BdvViewChanger.moveToLocation( sourcesPanel.getBdv(), location );
 		}
 	}
+
+	// public void loadAdditionalBookmarks(String bookmarksDirectory) {
+	// 	String bookmarksLocation = null;
+	// 	if ( bookmarksDirectory != null )
+	// 	{
+	// 		final GenericDialog gd = new GenericDialog( "Choose bookmarks source" );
+	// 		gd.addChoice( "Load bookmarks from", new String[]{ PROJECT, FILE_SYSTEM }, PROJECT );
+	// 		gd.showDialog();
+	// 		if ( gd.wasCanceled() ) return null;
+	// 		bookmarksLocation = gd.getNextChoice();
+	// 	}
+	//
+	// 	String bookmarksPath = null;
+	// 	if ( bookmarksDirectory != null && bookmarksLocation.equals( PROJECT ) && bookmarksDirectory.contains( "raw.githubusercontent" ) )
+	// 	{
+	// 		tablesPath = selectGitHubTablePath( tablesDirectory );
+	// 		if ( tablesPath == null ) return null;
+	// 	}
+	// 	else
+	// 	{
+	// 		final JFileChooser jFileChooser = new JFileChooser( tablesDirectory );
+	//
+	// 		if ( jFileChooser.showOpenDialog( null ) == JFileChooser.APPROVE_OPTION )
+	// 			tablesPath = jFileChooser.getSelectedFile().getAbsolutePath();
+	// 	}
+	//
+	// 	if ( tablesPath == null ) return null;
+	//
+	// 	if ( tablesPath.startsWith( "http" ) )
+	// 		tablesPath = resolveTableURL( URI.create( tablesPath ) );
+	//
+	// 	Map< String, List< String > > columns = TableColumns.openAndOrderNewColumns( table, mergeByColumnName, tablesPath );
+	//
+	// }
 
 	public void saveCurrentSettingsAsBookmark () {
 		// TODO - make bookmark name user definable

--- a/src/main/java/de/embl/cba/mobie/bookmark/BookmarksManager.java
+++ b/src/main/java/de/embl/cba/mobie/bookmark/BookmarksManager.java
@@ -78,6 +78,7 @@ public class BookmarksManager
 	}
 
 	public void saveCurrentSettingsAsBookmark () {
+		// TODO - make bookmark name user definable
 		Bookmark currentBookmark = getBookmarkFromCurrentSettings("test");
 		ArrayList<Bookmark> bookmarks = new ArrayList<>();
 		bookmarks.add(currentBookmark);

--- a/src/main/java/de/embl/cba/mobie/bookmark/BookmarksManager.java
+++ b/src/main/java/de/embl/cba/mobie/bookmark/BookmarksManager.java
@@ -140,8 +140,8 @@ public class BookmarksManager
 		MutableImageProperties sourceImageProperties = new MutableImageProperties();
 		Metadata sourceMetadata = sourcesPanel.getSourceAndCurrentMetadata(sourceName).metadata();
 
-		//TODO - read colour directly? Currently colouring doesn't work properly
-		sourceImageProperties.color = sourceMetadata.color;
+		ARGBType color = sourceMetadata.bdvStackSource.getConverterSetups().get(0).getColor();
+		sourceImageProperties.color = color.toString();
 
 		if (sourcesPanel.getSourceNameToLabelViews().containsKey(sourceName)) {
 			TableRowsTableView<TableRowImageSegment> sourceTableRowsTableView = sourceMetadata.views.getTableRowsTableView();

--- a/src/main/java/de/embl/cba/mobie/bookmark/BookmarksManager.java
+++ b/src/main/java/de/embl/cba/mobie/bookmark/BookmarksManager.java
@@ -93,10 +93,12 @@ public class BookmarksManager
 
 	public void loadAdditionalBookmarks() {
 			Map<String, Bookmark> additionalBookmarks = bookmarksJsonParser.selectAndLoadBookmarks();
-			nameToBookmark.putAll(additionalBookmarks);
-			bookmarkDropDown.removeAllItems();
-			for (String bookmarkName : nameToBookmark.keySet()) {
-				bookmarkDropDown.addItem(bookmarkName);
+			if (additionalBookmarks != null) {
+				nameToBookmark.putAll(additionalBookmarks);
+				bookmarkDropDown.removeAllItems();
+				for (String bookmarkName : nameToBookmark.keySet()) {
+					bookmarkDropDown.addItem(bookmarkName);
+				}
 			}
 	}
 

--- a/src/main/java/de/embl/cba/mobie/bookmark/BookmarksManager.java
+++ b/src/main/java/de/embl/cba/mobie/bookmark/BookmarksManager.java
@@ -108,7 +108,7 @@ public class BookmarksManager
 
 		if (bookmarkNameAndLocation.get(1) == FileUtils.PROJECT &&
 				bookmarksJsonParser.getDatasetLocation().contains( "raw.githubusercontent" )) {
-			bookmarksJsonParser.saveBookmarkToGithub(currentBookmark);
+			bookmarksJsonParser.saveBookmarksToGithub(bookmarks);
 		} else {
 			try {
 				bookmarksJsonParser.saveBookmarksToFile(bookmarks, bookmarkNameAndLocation.get(1));

--- a/src/main/java/de/embl/cba/mobie/bookmark/BookmarksManager.java
+++ b/src/main/java/de/embl/cba/mobie/bookmark/BookmarksManager.java
@@ -11,10 +11,7 @@ import de.embl.cba.mobie.bdv.BdvViewChanger;
 import de.embl.cba.mobie.utils.Utils;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 public class BookmarksManager
 {
@@ -82,6 +79,8 @@ public class BookmarksManager
 
 	public void saveCurrentSettingsAsBookmark () {
 		Bookmark currentBookmark = getBookmarkFromCurrentSettings("test");
+//		ArrayList<Bookmark> bookmarks = new ArrayList<>();
+//		bookmarks.add(currentBookmark);
 		HashMap<String, Bookmark> namesToBookmarks = new HashMap<>();
 		namesToBookmarks.put("test", currentBookmark);
 		try {

--- a/src/main/java/de/embl/cba/mobie/bookmark/BookmarksManager.java
+++ b/src/main/java/de/embl/cba/mobie/bookmark/BookmarksManager.java
@@ -11,6 +11,7 @@ import de.embl.cba.mobie.bdv.BdvViewChanger;
 import de.embl.cba.mobie.utils.Utils;
 import ij.gui.GenericDialog;
 
+import javax.swing.*;
 import java.io.IOException;
 import java.util.*;
 
@@ -21,8 +22,7 @@ public class BookmarksManager
 	private final SourcesPanel sourcesPanel;
 	private Map< String, Bookmark > nameToBookmark;
 	private BookmarksJsonParser bookmarksJsonParser;
-	private String PROJECT = "Project";
-	private String FILE_SYSTEM = "File system";
+	private JComboBox<String> bookmarkDropDown;
 
 	public BookmarksManager( SourcesPanel sourcesPanel, Map< String, Bookmark > nameToBookmark,
 							 BookmarksJsonParser bookmarksJsonParser )
@@ -30,6 +30,10 @@ public class BookmarksManager
 		this.sourcesPanel = sourcesPanel;
 		this.nameToBookmark = nameToBookmark;
 		this.bookmarksJsonParser = bookmarksJsonParser;
+	}
+
+	public void setBookmarkDropDown (JComboBox<String> bookmarkDropDown) {
+		this.bookmarkDropDown = bookmarkDropDown;
 	}
 
 	public void setView( String bookmarkId )
@@ -82,14 +86,13 @@ public class BookmarksManager
 		}
 	}
 
-	public void loadAdditionalBookmarks(String bookmarksDirectory) {
-		try {
-			String bookmarkPath = selectPathFromProjectOrFileSystem( bookmarksDirectory, "Bookmark" );
-
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
-
+	public void loadAdditionalBookmarks() {
+			Map<String, Bookmark> additionalBookmarks = bookmarksJsonParser.selectAndLoadBookmarks();
+			nameToBookmark.putAll(additionalBookmarks);
+			bookmarkDropDown.removeAllItems();
+			for (String bookmarkName : nameToBookmark.keySet()) {
+				bookmarkDropDown.addItem(bookmarkName);
+			}
 	}
 
 	public void saveCurrentSettingsAsBookmark () {

--- a/src/main/java/de/embl/cba/mobie/bookmark/BookmarksManager.java
+++ b/src/main/java/de/embl/cba/mobie/bookmark/BookmarksManager.java
@@ -3,19 +3,15 @@ package de.embl.cba.mobie.bookmark;
 import bdv.util.BdvHandle;
 import de.embl.cba.bdv.utils.BdvUtils;
 import de.embl.cba.bdv.utils.sources.Metadata;
-import de.embl.cba.bdv.utils.sources.Sources;
 import de.embl.cba.mobie.image.ImagePropertiesToMetadataAdapter;
 import de.embl.cba.mobie.image.MutableImageProperties;
 import de.embl.cba.mobie.ui.viewer.SourcesPanel;
 import de.embl.cba.mobie.bdv.BdvViewChanger;
 import de.embl.cba.mobie.utils.Utils;
-import ij.gui.GenericDialog;
 
 import javax.swing.*;
 import java.io.IOException;
 import java.util.*;
-
-import static de.embl.cba.tables.FileUtils.selectPathFromProjectOrFileSystem;
 
 public class BookmarksManager
 {
@@ -112,9 +108,7 @@ public class BookmarksManager
 		Set<String> visibleSourceNames = sourcesPanel.getVisibleSourceNames();
 
 		for (String sourceName : visibleSourceNames) {
-			Metadata sourceMetadata = sourcesPanel.getSourceAndMetadata(sourceName).metadata();
-			MutableImageProperties sourceImageProperties = new MutableImageProperties();
-			new ImagePropertiesToMetadataAdapter().setImageProperties(sourceMetadata, sourceImageProperties);
+			MutableImageProperties sourceImageProperties = sourcesPanel.getCurrentMutableImageProperties(sourceName);
 			layers.put(sourceName, sourceImageProperties);
 		}
 

--- a/src/main/java/de/embl/cba/mobie/bookmark/BookmarksManager.java
+++ b/src/main/java/de/embl/cba/mobie/bookmark/BookmarksManager.java
@@ -175,8 +175,15 @@ public class BookmarksManager
 			sourceImageProperties.showSelectedSegmentsIn3d = sourceMetadata.views.getSegments3dView().getShowSelectedSegmentsIn3D();
 		}
 
-		// TODO -read directly?
-		sourceImageProperties.showImageIn3d = sourceMetadata.showImageIn3d;
+		if (sourceMetadata.content != null) {
+			if (sourceMetadata.content.isVisible()) {
+				sourceImageProperties.showImageIn3d = true;
+			} else {
+				sourceImageProperties.showImageIn3d = false;
+			}
+		} else {
+			sourceImageProperties.showImageIn3d = false;
+		}
 
 		double[] currentContrastLimits = new double[2];
 		currentContrastLimits[0] = getConverterSetups( sourceMetadata.bdvStackSource ).get(0).getDisplayRangeMin();

--- a/src/main/java/de/embl/cba/mobie/bookmark/BookmarksManager.java
+++ b/src/main/java/de/embl/cba/mobie/bookmark/BookmarksManager.java
@@ -14,6 +14,8 @@ import ij.gui.GenericDialog;
 import java.io.IOException;
 import java.util.*;
 
+import static de.embl.cba.tables.FileUtils.selectPathFromProjectOrFileSystem;
+
 public class BookmarksManager
 {
 	private final SourcesPanel sourcesPanel;
@@ -80,39 +82,15 @@ public class BookmarksManager
 		}
 	}
 
-	// public void loadAdditionalBookmarks(String bookmarksDirectory) {
-	// 	String bookmarksLocation = null;
-	// 	if ( bookmarksDirectory != null )
-	// 	{
-	// 		final GenericDialog gd = new GenericDialog( "Choose bookmarks source" );
-	// 		gd.addChoice( "Load bookmarks from", new String[]{ PROJECT, FILE_SYSTEM }, PROJECT );
-	// 		gd.showDialog();
-	// 		if ( gd.wasCanceled() ) return null;
-	// 		bookmarksLocation = gd.getNextChoice();
-	// 	}
-	//
-	// 	String bookmarksPath = null;
-	// 	if ( bookmarksDirectory != null && bookmarksLocation.equals( PROJECT ) && bookmarksDirectory.contains( "raw.githubusercontent" ) )
-	// 	{
-	// 		tablesPath = selectGitHubTablePath( tablesDirectory );
-	// 		if ( tablesPath == null ) return null;
-	// 	}
-	// 	else
-	// 	{
-	// 		final JFileChooser jFileChooser = new JFileChooser( tablesDirectory );
-	//
-	// 		if ( jFileChooser.showOpenDialog( null ) == JFileChooser.APPROVE_OPTION )
-	// 			tablesPath = jFileChooser.getSelectedFile().getAbsolutePath();
-	// 	}
-	//
-	// 	if ( tablesPath == null ) return null;
-	//
-	// 	if ( tablesPath.startsWith( "http" ) )
-	// 		tablesPath = resolveTableURL( URI.create( tablesPath ) );
-	//
-	// 	Map< String, List< String > > columns = TableColumns.openAndOrderNewColumns( table, mergeByColumnName, tablesPath );
-	//
-	// }
+	public void loadAdditionalBookmarks(String bookmarksDirectory) {
+		try {
+			String bookmarkPath = selectPathFromProjectOrFileSystem( bookmarksDirectory, "Bookmark" );
+
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+
+	}
 
 	public void saveCurrentSettingsAsBookmark () {
 		// TODO - make bookmark name user definable

--- a/src/main/java/de/embl/cba/mobie/bookmark/BookmarksManager.java
+++ b/src/main/java/de/embl/cba/mobie/bookmark/BookmarksManager.java
@@ -79,13 +79,10 @@ public class BookmarksManager
 
 	public void saveCurrentSettingsAsBookmark () {
 		Bookmark currentBookmark = getBookmarkFromCurrentSettings("test");
-//		ArrayList<Bookmark> bookmarks = new ArrayList<>();
-//		bookmarks.add(currentBookmark);
-		HashMap<String, Bookmark> namesToBookmarks = new HashMap<>();
-		namesToBookmarks.put("test", currentBookmark);
+		ArrayList<Bookmark> bookmarks = new ArrayList<>();
+		bookmarks.add(currentBookmark);
 		try {
-			bookmarksJsonParser.writeBookmarksToFile("C:\\Users\\meechan\\Documents\\test.json",
-					namesToBookmarks);
+			bookmarksJsonParser.saveBookmarks(bookmarks);
 		} catch (IOException e) {
 			e.printStackTrace();
 		}

--- a/src/main/java/de/embl/cba/mobie/image/ImagePropertiesToMetadataAdapter.java
+++ b/src/main/java/de/embl/cba/mobie/image/ImagePropertiesToMetadataAdapter.java
@@ -6,6 +6,8 @@ import de.embl.cba.tables.color.ColorUtils;
 import net.imglib2.type.numeric.ARGBType;
 import org.apache.commons.lang.WordUtils;
 
+import java.util.ArrayList;
+
 import static de.embl.cba.mobie.utils.Utils.createRandom;
 
 public class ImagePropertiesToMetadataAdapter
@@ -31,5 +33,20 @@ public class ImagePropertiesToMetadataAdapter
 		metadata.showImageIn3d = imageProperties.showImageIn3d;
 		metadata.showSelectedSegmentsIn3d = imageProperties.showSelectedSegmentsIn3d;
 		metadata.additionalSegmentTableNames = imageProperties.tables;
+	}
+
+	public void setImageProperties( Metadata metadata, MutableImageProperties imageProperties) {
+		imageProperties.contrastLimits = metadata.contrastLimits != null
+				? metadata.contrastLimits : imageProperties.contrastLimits;
+		imageProperties.color = metadata.color != null
+				? metadata.color : imageProperties.color;
+		imageProperties.valueLimits = metadata.valueLimits != null
+				? metadata.valueLimits : imageProperties.valueLimits;
+
+		imageProperties.colorByColumn = metadata.colorByColumn;
+		imageProperties.selectedLabelIds = new ArrayList<>(metadata.selectedSegmentIds);
+		imageProperties.showImageIn3d = metadata.showImageIn3d;
+		imageProperties.showSelectedSegmentsIn3d = metadata.showSelectedSegmentsIn3d;
+		imageProperties.tables = new ArrayList<>(metadata.additionalSegmentTableNames);
 	}
 }

--- a/src/main/java/de/embl/cba/mobie/image/ImagePropertiesToMetadataAdapter.java
+++ b/src/main/java/de/embl/cba/mobie/image/ImagePropertiesToMetadataAdapter.java
@@ -44,9 +44,11 @@ public class ImagePropertiesToMetadataAdapter
 				? metadata.valueLimits : imageProperties.valueLimits;
 
 		imageProperties.colorByColumn = metadata.colorByColumn;
-		imageProperties.selectedLabelIds = new ArrayList<>(metadata.selectedSegmentIds);
+		imageProperties.selectedLabelIds = metadata.selectedSegmentIds != null
+				? new ArrayList<>(metadata.selectedSegmentIds) : imageProperties.selectedLabelIds;
 		imageProperties.showImageIn3d = metadata.showImageIn3d;
 		imageProperties.showSelectedSegmentsIn3d = metadata.showSelectedSegmentsIn3d;
-		imageProperties.tables = new ArrayList<>(metadata.additionalSegmentTableNames);
+		imageProperties.tables = metadata.additionalSegmentTableNames != null
+				? new ArrayList<>(metadata.additionalSegmentTableNames): imageProperties.tables;
 	}
 }

--- a/src/main/java/de/embl/cba/mobie/image/ImagePropertiesToMetadataAdapter.java
+++ b/src/main/java/de/embl/cba/mobie/image/ImagePropertiesToMetadataAdapter.java
@@ -12,7 +12,7 @@ import static de.embl.cba.mobie.utils.Utils.createRandom;
 
 public class ImagePropertiesToMetadataAdapter
 {
-	public void setMetadata( Metadata metadata, MutableImageProperties imageProperties )
+	public void setMetadataFromMutableImageProperties(Metadata metadata, MutableImageProperties imageProperties )
 	{
 		metadata.contrastLimits = imageProperties.contrastLimits != null
 				? imageProperties.contrastLimits : metadata.contrastLimits;
@@ -35,7 +35,7 @@ public class ImagePropertiesToMetadataAdapter
 		metadata.additionalSegmentTableNames = imageProperties.tables;
 	}
 
-	public void setImageProperties( Metadata metadata, MutableImageProperties imageProperties) {
+	public void setMutableImagePropertiesFromMetadata(MutableImageProperties imageProperties, Metadata metadata) {
 		imageProperties.contrastLimits = metadata.contrastLimits != null
 				? metadata.contrastLimits : imageProperties.contrastLimits;
 		imageProperties.color = metadata.color != null

--- a/src/main/java/de/embl/cba/mobie/image/SourcesModel.java
+++ b/src/main/java/de/embl/cba/mobie/image/SourcesModel.java
@@ -28,7 +28,7 @@ public class SourcesModel implements ImageSourcesModel
 	public static final String MASK_FILE_ID = "mask-";
 	private final MoBIEOptions.ImageDataStorageModality imageDataStorageModality;
 
-	private Map< String, SourceAndMetadata< ? > > nameToSourceAndMetadata;
+	private Map< String, SourceAndMetadata< ? > > nameToSourceAndDefaultMetadata;
 	private final String tableDataLocation;
 	private GlasbeyARGBLut glasbeyARGBLut;
 	private String storageModality;
@@ -39,7 +39,7 @@ public class SourcesModel implements ImageSourcesModel
 		this.imageDataStorageModality = imageDataStorageModality;
 		this.tableDataLocation = tableDataLocation;
 
-		nameToSourceAndMetadata = new HashMap<>();
+		nameToSourceAndDefaultMetadata = new HashMap<>();
 		glasbeyARGBLut = new GlasbeyARGBLut();
 
 		fetchSources( imageDataLocation );
@@ -48,7 +48,7 @@ public class SourcesModel implements ImageSourcesModel
 	@Override
 	public Map< String, SourceAndMetadata< ? > > sources()
 	{
-		return nameToSourceAndMetadata;
+		return nameToSourceAndDefaultMetadata;
 	}
 
 	@Override
@@ -93,17 +93,17 @@ public class SourcesModel implements ImageSourcesModel
 			adapter.setMetadata( metadata, properties );
 
 			final LazySpimSource lazySpimSource = new LazySpimSource( name, metadata.xmlLocation );
-			nameToSourceAndMetadata.put( name, new SourceAndMetadata( lazySpimSource, metadata ) );
+			nameToSourceAndDefaultMetadata.put( name, new SourceAndMetadata( lazySpimSource, metadata ) );
 			Sources.sourceToMetadata.put( lazySpimSource, metadata );
 		}
 
-		if ( nameToSourceAndMetadata.size() == 0)
+		if ( nameToSourceAndDefaultMetadata.size() == 0)
 		{
 			throw new UnsupportedOperationException( "No image data found in: "
 					+ FileAndUrlUtils.combinePath( imageDataLocation, "images", storageModality ) );
 		}
 
-		Utils.log("Found " + nameToSourceAndMetadata.size() + " image sources." );
+		Utils.log("Found " + nameToSourceAndDefaultMetadata.size() + " image sources." );
 	}
 
 	private Metadata initMetadata( String name )

--- a/src/main/java/de/embl/cba/mobie/image/SourcesModel.java
+++ b/src/main/java/de/embl/cba/mobie/image/SourcesModel.java
@@ -90,7 +90,7 @@ public class SourcesModel implements ImageSourcesModel
 			metadata.type = Enums.valueOf( Metadata.Type.class, properties.type );
 
 			final ImagePropertiesToMetadataAdapter adapter = new ImagePropertiesToMetadataAdapter();
-			adapter.setMetadata( metadata, properties );
+			adapter.setMetadataFromMutableImageProperties( metadata, properties );
 
 			final LazySpimSource lazySpimSource = new LazySpimSource( name, metadata.xmlLocation );
 			nameToSourceAndDefaultMetadata.put( name, new SourceAndMetadata( lazySpimSource, metadata ) );

--- a/src/main/java/de/embl/cba/mobie/ui/viewer/ActionPanel.java
+++ b/src/main/java/de/embl/cba/mobie/ui/viewer/ActionPanel.java
@@ -5,6 +5,7 @@ import de.embl.cba.bdv.utils.BdvUtils;
 import de.embl.cba.bdv.utils.Logger;
 import de.embl.cba.bdv.utils.popup.BdvPopupMenus;
 import de.embl.cba.bdv.utils.sources.Metadata;
+import de.embl.cba.mobie.bookmark.Bookmark;
 import de.embl.cba.mobie.bookmark.Location;
 import de.embl.cba.mobie.bookmark.LocationType;
 import de.embl.cba.mobie.platybrowser.GeneSearch;
@@ -100,6 +101,13 @@ public class ActionPanel extends JPanel
 						Logger.log( "View:\n" + BdvUtils.getBdvViewerTransformString( bdv ) );
 						Logger.log( "Normalised view:\n" + Utils.createNormalisedViewerTransformString( bdv, Utils.getMousePosition( bdv ) ) );
 					} )).start();
+				});
+
+		BdvPopupMenus.addAction(bdv, "Save Current Settings As Bookmark",
+				() -> {
+					(new Thread( () -> {
+						bookmarksManager.saveCurrentSettingsAsBookmark();
+						} )).start();
 				});
 
 		BdvPopupMenus.addAction( bdv, "Restore Default View" + BdvUtils.getShortCutString( RESTORE_DEFAULT_VIEW_TRIGGER ) ,

--- a/src/main/java/de/embl/cba/mobie/ui/viewer/ActionPanel.java
+++ b/src/main/java/de/embl/cba/mobie/ui/viewer/ActionPanel.java
@@ -103,6 +103,13 @@ public class ActionPanel extends JPanel
 					} )).start();
 				});
 
+		BdvPopupMenus.addAction(bdv, "Load Additional Bookmarks",
+				() -> {
+					(new Thread( () -> {
+						// bookmarksManager.loadAdditionalBookmarks();
+					} )).start();
+				});
+
 		BdvPopupMenus.addAction(bdv, "Save Current Settings As Bookmark",
 				() -> {
 					(new Thread( () -> {

--- a/src/main/java/de/embl/cba/mobie/ui/viewer/ActionPanel.java
+++ b/src/main/java/de/embl/cba/mobie/ui/viewer/ActionPanel.java
@@ -377,7 +377,7 @@ public class ActionPanel extends JPanel
 
 			String selectionName = sourceName.replace( modality + "-", "" );
 
-			final Metadata metadata = sourcesPanel.getSourceAndMetadata( sourceName ).metadata();
+			final Metadata metadata = sourcesPanel.getSourceAndDefaultMetadata( sourceName ).metadata();
 
 			if ( metadata.type.equals( Metadata.Type.Segmentation ) )
 			{

--- a/src/main/java/de/embl/cba/mobie/ui/viewer/ActionPanel.java
+++ b/src/main/java/de/embl/cba/mobie/ui/viewer/ActionPanel.java
@@ -106,7 +106,7 @@ public class ActionPanel extends JPanel
 		BdvPopupMenus.addAction(bdv, "Load Additional Bookmarks",
 				() -> {
 					(new Thread( () -> {
-						// bookmarksManager.loadAdditionalBookmarks();
+						bookmarksManager.loadAdditionalBookmarks();
 					} )).start();
 				});
 

--- a/src/main/java/de/embl/cba/mobie/ui/viewer/ActionPanel.java
+++ b/src/main/java/de/embl/cba/mobie/ui/viewer/ActionPanel.java
@@ -5,7 +5,6 @@ import de.embl.cba.bdv.utils.BdvUtils;
 import de.embl.cba.bdv.utils.Logger;
 import de.embl.cba.bdv.utils.popup.BdvPopupMenus;
 import de.embl.cba.bdv.utils.sources.Metadata;
-import de.embl.cba.mobie.bookmark.Bookmark;
 import de.embl.cba.mobie.bookmark.Location;
 import de.embl.cba.mobie.bookmark.LocationType;
 import de.embl.cba.mobie.platybrowser.GeneSearch;
@@ -68,7 +67,7 @@ public class ActionPanel extends JPanel
 		this.add( new JSeparator( SwingConstants.HORIZONTAL ) );
 		addSourceSelectionUI( this );
 		this.add( new JSeparator( SwingConstants.HORIZONTAL ) );
-		addBookmarksUI( this  );
+		bookmarksManager.setBookmarkDropDown( addBookmarksUI( this  ) );
 		addMoveToLocationUI( this );
 		addLevelingUI( this );
 		configPanel();
@@ -496,7 +495,7 @@ public class ActionPanel extends JPanel
 		panel.add( horizontalLayoutPanel );
 	}
 
-	private void addBookmarksUI( JPanel panel )
+	private JComboBox<String> addBookmarksUI( JPanel panel )
 	{
 		final JPanel horizontalLayoutPanel = SwingUtils.horizontalLayoutPanel();
 
@@ -513,6 +512,8 @@ public class ActionPanel extends JPanel
 		horizontalLayoutPanel.add( button );
 
 		panel.add( horizontalLayoutPanel );
+
+		return comboBox;
 	}
 
 	private JButton getButton( String buttonLabel )

--- a/src/main/java/de/embl/cba/mobie/ui/viewer/MoBIEViewer.java
+++ b/src/main/java/de/embl/cba/mobie/ui/viewer/MoBIEViewer.java
@@ -205,9 +205,10 @@ public class MoBIEViewer
 
 	public BookmarksManager fetchBookmarks( String location )
 	{
-		Map< String, Bookmark > nameToBookmark = new BookmarksJsonParser( location ).getBookmarks();
+		BookmarksJsonParser bookmarkParser = new BookmarksJsonParser(location);
+		Map< String, Bookmark > nameToBookmark = bookmarkParser.getBookmarks();
 
-		return new BookmarksManager( sourcesPanel, nameToBookmark );
+		return new BookmarksManager( sourcesPanel, nameToBookmark, bookmarkParser);
 	}
 
 	public void setLogWindowPositionAndSize( JFrame jFrame )

--- a/src/main/java/de/embl/cba/mobie/ui/viewer/MoBIEViewer.java
+++ b/src/main/java/de/embl/cba/mobie/ui/viewer/MoBIEViewer.java
@@ -206,7 +206,7 @@ public class MoBIEViewer
 	public BookmarksManager fetchBookmarks( String location )
 	{
 		BookmarksJsonParser bookmarkParser = new BookmarksJsonParser(location);
-		Map< String, Bookmark > nameToBookmark = bookmarkParser.getBookmarks();
+		Map< String, Bookmark > nameToBookmark = bookmarkParser.getDefaultBookmarks();
 
 		return new BookmarksManager( sourcesPanel, nameToBookmark, bookmarkParser);
 	}

--- a/src/main/java/de/embl/cba/mobie/ui/viewer/SourcesDisplayUI.java
+++ b/src/main/java/de/embl/cba/mobie/ui/viewer/SourcesDisplayUI.java
@@ -89,7 +89,7 @@ public class SourcesDisplayUI
 	}
 
 
-	private static ArrayList< ConverterSetup > getConverterSetups(
+	public static ArrayList< ConverterSetup > getConverterSetups(
 			BdvStackSource bdvStackSource )
 	{
 		bdvStackSource.setCurrent();

--- a/src/main/java/de/embl/cba/mobie/ui/viewer/SourcesDisplayUI.java
+++ b/src/main/java/de/embl/cba/mobie/ui/viewer/SourcesDisplayUI.java
@@ -11,6 +11,8 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
 
+import static de.embl.cba.bdv.utils.BdvUtils.getConverterSetups;
+
 public class SourcesDisplayUI
 {
 	public static JCheckBox createBigDataViewerVisibilityCheckbox(
@@ -86,19 +88,6 @@ public class SourcesDisplayUI
 		} );
 
 		return button;
-	}
-
-
-	public static ArrayList< ConverterSetup > getConverterSetups(
-			BdvStackSource bdvStackSource )
-	{
-		bdvStackSource.setCurrent();
-		final int sourceIndex = bdvStackSource.getBdvHandle()
-				.getViewerPanel().getVisibilityAndGrouping().getCurrentSource();
-		final ArrayList< ConverterSetup > converterSetups = new ArrayList<>();
-		converterSetups.add( bdvStackSource.getBdvHandle()
-				.getSetupAssignments().getConverterSetups().get( sourceIndex ) );
-		return converterSetups;
 	}
 
 

--- a/src/main/java/de/embl/cba/mobie/ui/viewer/SourcesPanel.java
+++ b/src/main/java/de/embl/cba/mobie/ui/viewer/SourcesPanel.java
@@ -126,11 +126,6 @@ public class SourcesPanel extends JPanel
 
     private void setSourceColor( SourceAndMetadata< ? > sam, Color color, JPanel panel )
     {
-        // TODO - save this another way? At the moment, this means that adding an image from the GUI will
-        // result in this metadata being the default, and colour changes persisting. If you load from a bookmark,
-        // this metadata will not be the default, and these changes won't persist.
-        sam.metadata().color = color.toString();
-
         sam.metadata().bdvStackSource.setColor( ColorUtils.getARGBType( color ) );
 
         if ( sam.metadata().content != null )

--- a/src/main/java/de/embl/cba/mobie/ui/viewer/SourcesPanel.java
+++ b/src/main/java/de/embl/cba/mobie/ui/viewer/SourcesPanel.java
@@ -73,11 +73,6 @@ public class SourcesPanel extends JPanel
 
     public static void updateSource3dView( SourceAndMetadata< ? > sam, SourcesPanel sourcesPanel, boolean showImageIn3d )
     {
-        // TODO - save this another way? At the moment, this means that adding an image from the GUI will
-        // result in this metadata being the default, and showImageIn3d persisting. If you load from a bookmark,
-        // this metadata will not be the default, and these changes won't persist.
-        sam.metadata().showImageIn3d = showImageIn3d;
-
         if ( sam.metadata().type.equals( Metadata.Type.Segmentation ) ) return;
 
         if ( showImageIn3d )

--- a/src/main/java/de/embl/cba/mobie/ui/viewer/SourcesPanel.java
+++ b/src/main/java/de/embl/cba/mobie/ui/viewer/SourcesPanel.java
@@ -542,7 +542,7 @@ public class SourcesPanel extends JPanel
         for ( String tableName : sam.metadata().additionalSegmentTableNames )
         {
             String newTablePath = FileAndUrlUtils.combinePath( tablesLocation, tableName + ".csv" );
-            tableRowsTableView.addAdditionalTables(newTablePath);
+            tableRowsTableView.addAdditionalTable(newTablePath);
 
             if ( newTablePath.startsWith( "http" ) )
                 newTablePath = FileUtils.resolveTableURL( URI.create( newTablePath ) );

--- a/src/main/java/de/embl/cba/mobie/ui/viewer/SourcesPanel.java
+++ b/src/main/java/de/embl/cba/mobie/ui/viewer/SourcesPanel.java
@@ -340,9 +340,6 @@ public class SourcesPanel extends JPanel
             Logger.log( "Adding source: " + sourceName + "..." );
             sourceNameToSourceAndMetadata.put( sourceName, sam );
 
-            MutableImageProperties sourceImageProperties = new MutableImageProperties();
-            new ImagePropertiesToMetadataAdapter().setImageProperties(sam.metadata(), sourceImageProperties);
-
             addSourceToViewer( sam );
             SwingUtilities.invokeLater( () -> addSourceToPanel( sam ) );
         }

--- a/src/main/java/de/embl/cba/mobie/ui/viewer/SourcesPanel.java
+++ b/src/main/java/de/embl/cba/mobie/ui/viewer/SourcesPanel.java
@@ -321,12 +321,18 @@ public class SourcesPanel extends JPanel
         MutableImageProperties sourceImageProperties = sourceNameToCurrentMutableImageProperties.get(sourceName);
         Metadata sourceDefaultMetadata = getSourceAndDefaultMetadata(sourceName).metadata();
 
-        // color is set on the fly in setSourceColor
+        // color is set on the fly in setSourceColor (for solid colours)
         if (sourceNameToLabelViews.containsKey(sourceName)) {
             TableRowsTableView< TableRowImageSegment > sourceTableRowsTableView = sourceDefaultMetadata.views.getTableRowsTableView();
-            sourceImageProperties.color = sourceTableRowsTableView.getColorByColumnLUT();
-            sourceImageProperties.colorByColumn = sourceTableRowsTableView.getColoringColumnName();
-            sourceImageProperties.valueLimits = sourceTableRowsTableView.getColorByColumnValueLimits();
+
+            if (!sourceDefaultMetadata.views.getSegmentsBdvView().isLabelMaskShownAsBinaryMask()) {
+                sourceImageProperties.color = sourceTableRowsTableView.getColoringLUTName();
+                sourceImageProperties.colorByColumn = sourceTableRowsTableView.getColoringColumnName();
+                sourceImageProperties.valueLimits = sourceTableRowsTableView.getColorByColumnValueLimits();
+            } else {
+                sourceImageProperties.colorByColumn = null;
+                sourceImageProperties.valueLimits = null;
+            }
 
             ArrayList<TableRowImageSegment> selectedSegments = sourceTableRowsTableView.getSelectedLabelIds();
             if (selectedSegments != null) {
@@ -340,6 +346,9 @@ public class SourcesPanel extends JPanel
             }
 
             if (sourceTableRowsTableView.getAdditionalTables() != null) {
+                if (sourceImageProperties.tables == null) {
+                    sourceImageProperties.tables = new ArrayList<>();
+                }
                 for (String tableName : sourceTableRowsTableView.getAdditionalTables()) {
                     if (!sourceImageProperties.tables.contains(tableName)) {
                         sourceImageProperties.tables.add(tableName);

--- a/src/main/java/de/embl/cba/mobie/ui/viewer/SourcesPanel.java
+++ b/src/main/java/de/embl/cba/mobie/ui/viewer/SourcesPanel.java
@@ -8,8 +8,6 @@ import de.embl.cba.bdv.utils.lut.GlasbeyARGBLut;
 import de.embl.cba.bdv.utils.sources.ARGBConvertedRealSource;
 import de.embl.cba.bdv.utils.sources.Metadata;
 import de.embl.cba.mobie.Constants;
-import de.embl.cba.mobie.image.ImagePropertiesToMetadataAdapter;
-import de.embl.cba.mobie.image.MutableImageProperties;
 import de.embl.cba.mobie.image.SourcesModel;
 import de.embl.cba.tables.FileAndUrlUtils;
 import de.embl.cba.tables.FileUtils;
@@ -41,7 +39,6 @@ import java.net.URI;
 import java.util.*;
 import java.util.List;
 
-import static de.embl.cba.mobie.ui.viewer.SourcesDisplayUI.getConverterSetups;
 import static de.embl.cba.mobie.utils.Utils.createAnnotatedImageSegmentsFromTableFile;
 import static de.embl.cba.mobie.utils.Utils.createRandom;
 
@@ -49,7 +46,7 @@ public class SourcesPanel extends JPanel
 {
     private final Map< String, SegmentsTableBdvAnd3dViews > sourceNameToLabelViews;
     private Map< String, JPanel > sourceNameToPanel;
-    private Map< String, SourceAndMetadata< ? > > sourceNameToSourceAndMetadata;
+    private Map< String, SourceAndMetadata< ? > > sourceNameToSourceAndCurrentMetadata;
     private BdvHandle bdv;
     private final SourcesModel imageSourcesModel;
     private Image3DUniverse universe;
@@ -63,7 +60,7 @@ public class SourcesPanel extends JPanel
         this.imageSourcesModel = imageSourcesModel;
         sourceNameToPanel = new LinkedHashMap<>();
         sourceNameToLabelViews = new LinkedHashMap<>();
-        sourceNameToSourceAndMetadata = new LinkedHashMap<>();
+        sourceNameToSourceAndCurrentMetadata = new LinkedHashMap<>();
 
         voxelSpacing3DView = 0.05;
         meshSmoothingIterations = 5;
@@ -145,7 +142,7 @@ public class SourcesPanel extends JPanel
             return;
         }
 
-        final SourceAndMetadata< ? > sam = sourceNameToSourceAndMetadata.get(sourceName);
+        final SourceAndMetadata< ? > sam = sourceNameToSourceAndCurrentMetadata.get(sourceName);
         final JPanel jPanel = sourceNameToPanel.get( sourceName );
 
         setSourceColor( sam, color, jPanel );
@@ -302,7 +299,7 @@ public class SourcesPanel extends JPanel
 
     // necessary as loading from bookmark creates a new sourceAndMetadata that is separate from the default
     public SourceAndMetadata< ? > getSourceAndCurrentMetadata(String sourceName) {
-        return sourceNameToSourceAndMetadata.get(sourceName);
+        return sourceNameToSourceAndCurrentMetadata.get(sourceName);
     }
 
     public ArrayList< String > getSourceNames()
@@ -338,7 +335,7 @@ public class SourcesPanel extends JPanel
         else
         {
             Logger.log( "Adding source: " + sourceName + "..." );
-            sourceNameToSourceAndMetadata.put( sourceName, sam );
+            sourceNameToSourceAndCurrentMetadata.put( sourceName, sam );
 
             addSourceToViewer( sam );
             SwingUtilities.invokeLater( () -> addSourceToPanel( sam ) );
@@ -708,7 +705,7 @@ public class SourcesPanel extends JPanel
 
     public void removeSourceFromPanelAndViewers( String sourceName )
     {
-        removeSourceFromPanelAndViewers( sourceNameToSourceAndMetadata.get( sourceName ) );
+        removeSourceFromPanelAndViewers( sourceNameToSourceAndCurrentMetadata.get( sourceName ) );
     }
 
     private void removeSourceFromPanelAndViewers( SourceAndMetadata< ? > sam )
@@ -718,7 +715,7 @@ public class SourcesPanel extends JPanel
 
         removeSourceFromPanel( sam.metadata().displayName );
 		removeLabelViews( sam.metadata().displayName );
-		sourceNameToSourceAndMetadata.remove( sam.metadata().displayName );
+		sourceNameToSourceAndCurrentMetadata.remove( sam.metadata().displayName );
 
 		BdvUtils.removeSource( bdv, ( BdvStackSource ) sam.metadata().bdvStackSource );
 


### PR DESCRIPTION
Main changes:
- Only bookmarks in default.json are loaded by default
- Other bookmarks are loaded via the context menu 'load additional bookmarks..' and follows the same logic (and uses most of the same code) as loading additional tables. i.e. can select from file on project or file system
- Bookmarks can be saved via the context menu 'save current settings as bookmark..' with similar logic to above. i.e. can select to save to project or to file system. For saving to a project on github, at the moment this works the same as PlateViewer, and requires an access token with push access to the repo. For saving to project or file system, if you select a file that already exists, it will append to that file. (appending to json files is actually a pain, so really it parses the file, appends the new bookmark and saves it again - it works ok though)
- Bookmark settings no longer persist

There are also changes to imagej-utils - pull request soon!

Deals with issues: https://github.com/mobie/mobie-viewer-fiji/issues/133 and https://github.com/mobie/mobie-viewer-fiji/issues/83