### PR TITLE
add resolution 3d

### DIFF
--- a/src/main/java/de/embl/cba/mobie/image/ImagePropertiesToMetadataAdapter.java
+++ b/src/main/java/de/embl/cba/mobie/image/ImagePropertiesToMetadataAdapter.java
@@ -20,6 +20,7 @@ public class ImagePropertiesToMetadataAdapter
 				? imageProperties.color : metadata.color;
 		metadata.valueLimits = imageProperties.valueLimits != null
 				? imageProperties.valueLimits : metadata.valueLimits;
+		metadata.resolution3dView = imageProperties.resolution3dView;
 
 		if ( metadata.color != null )
 		{
@@ -42,6 +43,7 @@ public class ImagePropertiesToMetadataAdapter
 				? metadata.color : imageProperties.color;
 		imageProperties.valueLimits = metadata.valueLimits != null
 				? metadata.valueLimits : imageProperties.valueLimits;
+		imageProperties.resolution3dView = metadata.resolution3dView;
 
 		imageProperties.colorByColumn = metadata.colorByColumn;
 		imageProperties.selectedLabelIds = metadata.selectedSegmentIds != null

--- a/src/main/java/de/embl/cba/mobie/image/MutableImageProperties.java
+++ b/src/main/java/de/embl/cba/mobie/image/MutableImageProperties.java
@@ -8,6 +8,7 @@ public class MutableImageProperties
 	public String colorByColumn;
 	public double[] contrastLimits;
 	public double[] valueLimits;
+	public double resolution3dView;
 	public ArrayList< String > tables;
 	public ArrayList< Double > selectedLabelIds;
 	public boolean showSelectedSegmentsIn3d;


### PR DESCRIPTION
I added the 3d resolution to the metadata / imageproperties. 
I will need to add a bit to the function here: https://github.com/mobie/mobie-viewer-fiji/blob/master/src/main/java/de/embl/cba/mobie/bookmark/BookmarksManager.java#L170 when you're done. It needs a getter for the current resolution 3d value. This is so the current value can be written to a bookmark, if it has been changed via the context menu.