### PR TITLE
Remove s3 authentication code in favor of dynamic credentials

### DIFF
--- a/src/main/java/de/embl/cba/mobie/n5/N5S3ImageLoader.java
+++ b/src/main/java/de/embl/cba/mobie/n5/N5S3ImageLoader.java
@@ -29,14 +29,8 @@
  */
 package de.embl.cba.mobie.n5;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.AnonymousAWSCredentials;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
-import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import de.embl.cba.tables.S3CredentialsCreator;
+import de.embl.cba.tables.S3Utils;
 import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
 import org.janelia.saalfeldlab.n5.s3.N5AmazonS3Reader;
 
@@ -48,34 +42,24 @@ public class N5S3ImageLoader extends N5ImageLoader
 	private final String signingRegion;
 	private final String bucketName;
 	private final String key;
-	private final S3CredentialsCreator.S3Authentication authentication;
 
 	static class N5AmazonS3ReaderCreator
 	{
 
-		public N5AmazonS3Reader create( String serviceEndpoint, String signingRegion, String bucketName, String key, S3CredentialsCreator.S3Authentication authentication ) throws IOException
+		public N5AmazonS3Reader create( String serviceEndpoint, String signingRegion, String bucketName, String key ) throws IOException
 		{
-			final AwsClientBuilder.EndpointConfiguration endpoint = new AwsClientBuilder.EndpointConfiguration( serviceEndpoint, signingRegion );
-
-			final AmazonS3 s3 = AmazonS3ClientBuilder
-					.standard()
-					.withPathStyleAccessEnabled( true )
-					.withEndpointConfiguration( endpoint )
-					.withCredentials( S3CredentialsCreator.getCredentialsProvider( authentication ) )
-					.build();
-
+			final AmazonS3 s3 = S3Utils.getS3Client( serviceEndpoint, signingRegion, bucketName );
 			return new N5AmazonS3Reader( s3, bucketName, key );
 		}
 	}
 
-	public N5S3ImageLoader( String serviceEndpoint, String signingRegion, String bucketName, String key, S3CredentialsCreator.S3Authentication authentication, AbstractSequenceDescription< ?, ?, ? > sequenceDescription ) throws IOException
+	public N5S3ImageLoader( String serviceEndpoint, String signingRegion, String bucketName, String key, AbstractSequenceDescription< ?, ?, ? > sequenceDescription ) throws IOException
 	{
-		super( new N5AmazonS3ReaderCreator().create( serviceEndpoint, signingRegion, bucketName, key, authentication ), sequenceDescription );
+		super( new N5AmazonS3ReaderCreator().create( serviceEndpoint, signingRegion, bucketName, key ), sequenceDescription );
 		this.serviceEndpoint = serviceEndpoint;
 		this.signingRegion = signingRegion;
 		this.bucketName = bucketName;
 		this.key = key;
-		this.authentication = authentication;
 	}
 
 	public String getServiceEndpoint()
@@ -98,8 +82,4 @@ public class N5S3ImageLoader extends N5ImageLoader
 		return key;
 	}
 
-	public S3CredentialsCreator.S3Authentication getAuthentication()
-	{
-		return authentication;
-	}
 }

--- a/src/main/java/de/embl/cba/mobie/n5/XmlIoN5S3ImageLoader.java
+++ b/src/main/java/de/embl/cba/mobie/n5/XmlIoN5S3ImageLoader.java
@@ -34,7 +34,6 @@ import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
 import mpicbg.spim.data.generic.sequence.ImgLoaderIo;
 import mpicbg.spim.data.generic.sequence.XmlIoBasicImgLoader;
 import org.jdom2.Element;
-import de.embl.cba.tables.S3CredentialsCreator;
 
 import java.io.File;
 import java.io.IOException;
@@ -48,7 +47,6 @@ public class XmlIoN5S3ImageLoader implements XmlIoBasicImgLoader< N5S3ImageLoade
 	public static final String SIGNING_REGION = "SigningRegion";
 	public static final String BUCKET_NAME = "BucketName";
 	public static final String KEY = "Key";
-	public static final String AUTHENTICATION = "Authentication";
 
 
 	@Override
@@ -61,7 +59,6 @@ public class XmlIoN5S3ImageLoader implements XmlIoBasicImgLoader< N5S3ImageLoade
 		elem.setAttribute( SIGNING_REGION, imgLoader.getSigningRegion() );
 		elem.setAttribute( BUCKET_NAME, imgLoader.getBucketName() );
 		elem.setAttribute( KEY, imgLoader.getKey() );
-		elem.setAttribute( AUTHENTICATION, imgLoader.getAuthentication().toString() );
 
 		return elem;
 	}
@@ -75,11 +72,10 @@ public class XmlIoN5S3ImageLoader implements XmlIoBasicImgLoader< N5S3ImageLoade
 		final String signingRegion = XmlHelpers.getText( elem, SIGNING_REGION );
 		final String bucketName = XmlHelpers.getText( elem, BUCKET_NAME );
 		final String key = XmlHelpers.getText( elem, KEY );
-		final S3CredentialsCreator.S3Authentication authentication = S3CredentialsCreator.S3Authentication.valueOf( XmlHelpers.getText( elem, AUTHENTICATION ) );
 
 		try
 		{
-			return new N5S3ImageLoader( serviceEndpoint, signingRegion, bucketName, key, authentication, sequenceDescription );
+			return new N5S3ImageLoader( serviceEndpoint, signingRegion, bucketName, key, sequenceDescription );
 		}
 		catch ( IOException e )
 		{

--- a/src/main/java/de/embl/cba/mobie/n5/XmlIoN5S3ZarrImageLoader.java
+++ b/src/main/java/de/embl/cba/mobie/n5/XmlIoN5S3ZarrImageLoader.java
@@ -30,7 +30,6 @@
 package de.embl.cba.mobie.n5;
 
 import de.embl.cba.mobie.n5.zarr.N5S3OMEZarrImageLoader;
-import de.embl.cba.tables.S3CredentialsCreator;
 import mpicbg.spim.data.XmlHelpers;
 import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
 import mpicbg.spim.data.generic.sequence.ImgLoaderIo;
@@ -51,7 +50,6 @@ public class XmlIoN5S3ZarrImageLoader implements XmlIoBasicImgLoader< N5S3OMEZar
 	public static final String SIGNING_REGION = "SigningRegion";
 	public static final String BUCKET_NAME = "BucketName";
 	public static final String KEY = "Key";
-	public static final String AUTHENTICATION = "Authentication";
 
 	@Override
 	public Element toXml( final N5S3OMEZarrImageLoader imgLoader, final File basePath )
@@ -63,7 +61,6 @@ public class XmlIoN5S3ZarrImageLoader implements XmlIoBasicImgLoader< N5S3OMEZar
 		elem.setAttribute( SIGNING_REGION, imgLoader.getSigningRegion() );
 		elem.setAttribute( BUCKET_NAME, imgLoader.getBucketName() );
 		elem.setAttribute( KEY, imgLoader.getKey() );
-		elem.setAttribute( AUTHENTICATION, imgLoader.getAuthentication().toString() );
 
 		return elem;
 	}
@@ -77,11 +74,10 @@ public class XmlIoN5S3ZarrImageLoader implements XmlIoBasicImgLoader< N5S3OMEZar
 		final String signingRegion = XmlHelpers.getText( elem, SIGNING_REGION );
 		final String bucketName = XmlHelpers.getText( elem, BUCKET_NAME );
 		final String key = XmlHelpers.getText( elem, KEY );
-		final S3CredentialsCreator.S3Authentication authentication = S3CredentialsCreator.S3Authentication.valueOf( XmlHelpers.getText( elem, AUTHENTICATION ) );
 
 		try
 		{
-			return new N5S3OMEZarrImageLoader( serviceEndpoint, signingRegion, bucketName, key, authentication, sequenceDescription );
+			return new N5S3OMEZarrImageLoader( serviceEndpoint, signingRegion, bucketName, key, sequenceDescription );
 		}
 		catch ( IOException e )
 		{

--- a/src/main/java/de/embl/cba/mobie/n5/zarr/N5S3OMEZarrImageLoader.java
+++ b/src/main/java/de/embl/cba/mobie/n5/zarr/N5S3OMEZarrImageLoader.java
@@ -29,12 +29,8 @@
  */
 package de.embl.cba.mobie.n5.zarr;
 
-import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import de.embl.cba.tables.S3CredentialsCreator;
-import de.embl.cba.mobie.n5.zarr.N5OMEZarrImageLoader;
-import de.embl.cba.mobie.n5.zarr.N5S3ZarrReader;
+import de.embl.cba.tables.S3Utils;
 import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
 
 import java.io.IOException;
@@ -47,45 +43,34 @@ public class N5S3OMEZarrImageLoader extends N5OMEZarrImageLoader
 	private final String signingRegion;
 	private final String bucketName;
 	private final String key;
-	private final S3CredentialsCreator.S3Authentication authentication;
 
 	static class  N5S3ZarrReaderCreator
 	{
-		public N5S3ZarrReader create( String serviceEndpoint, String signingRegion, String bucketName, String key, S3CredentialsCreator.S3Authentication authentication ) throws IOException
+		public N5S3ZarrReader create( String serviceEndpoint, String signingRegion, String bucketName, String key ) throws IOException
 		{
-			final AwsClientBuilder.EndpointConfiguration endpoint = new AwsClientBuilder.EndpointConfiguration( serviceEndpoint, signingRegion );
-
-			final AmazonS3 s3 = AmazonS3ClientBuilder
-					.standard()
-					.withPathStyleAccessEnabled( true )
-					.withEndpointConfiguration( endpoint )
-					.withCredentials( S3CredentialsCreator.getCredentialsProvider( authentication ) )
-					.build();
-
+			final AmazonS3 s3 = S3Utils.getS3Client( serviceEndpoint, signingRegion, bucketName );
 			return new N5S3ZarrReader( s3, serviceEndpoint, bucketName, key );
 		}
 	}
 
 	// sequenceDescription has been read from xml
-	public N5S3OMEZarrImageLoader( String serviceEndpoint, String signingRegion, String bucketName, String key, S3CredentialsCreator.S3Authentication authentication, AbstractSequenceDescription< ?, ?, ? > sequenceDescription ) throws IOException
+	public N5S3OMEZarrImageLoader( String serviceEndpoint, String signingRegion, String bucketName, String key, AbstractSequenceDescription< ?, ?, ? > sequenceDescription ) throws IOException
 	{
-		super( new N5S3ZarrReaderCreator().create( serviceEndpoint, signingRegion, bucketName, key, authentication ), sequenceDescription );
+		super( new N5S3ZarrReaderCreator().create( serviceEndpoint, signingRegion, bucketName, key ), sequenceDescription );
 		this.serviceEndpoint = serviceEndpoint;
 		this.signingRegion = signingRegion;
 		this.bucketName = bucketName;
 		this.key = key;
-		this.authentication = authentication;
 	}
 
 	// sequenceDescription will be read from zarr
-	public N5S3OMEZarrImageLoader( String serviceEndpoint, String signingRegion, String bucketName, String key, S3CredentialsCreator.S3Authentication authentication ) throws IOException
+	public N5S3OMEZarrImageLoader( String serviceEndpoint, String signingRegion, String bucketName, String key ) throws IOException
 	{
-		super( new N5S3ZarrReaderCreator().create( serviceEndpoint, signingRegion, bucketName, key, authentication ) );
+		super( new N5S3ZarrReaderCreator().create( serviceEndpoint, signingRegion, bucketName, key ) );
 		this.serviceEndpoint = serviceEndpoint;
 		this.signingRegion = signingRegion;
 		this.bucketName = bucketName;
 		this.key = key;
-		this.authentication = authentication;
 	}
 
 	public String getServiceEndpoint()
@@ -106,10 +91,5 @@ public class N5S3OMEZarrImageLoader extends N5OMEZarrImageLoader
 	public String getKey()
 	{
 		return key;
-	}
-
-	public S3CredentialsCreator.S3Authentication getAuthentication()
-	{
-		return authentication;
 	}
 }

--- a/src/main/java/de/embl/cba/mobie/n5/zarr/OMEZarrS3Reader.java
+++ b/src/main/java/de/embl/cba/mobie/n5/zarr/OMEZarrS3Reader.java
@@ -4,7 +4,6 @@ import bdv.util.BdvFunctions;
 import bdv.util.BdvOptions;
 import bdv.util.BdvStackSource;
 import de.embl.cba.mobie.n5.source.Sources;
-import de.embl.cba.tables.S3CredentialsCreator;
 import ij.IJ;
 import mpicbg.spim.data.SpimData;
 import net.imglib2.type.numeric.ARGBType;
@@ -39,7 +38,7 @@ public class OMEZarrS3Reader
 	public SpimData readKey( String key ) throws IOException
 	{
 		N5OMEZarrImageLoader.logChunkLoading = logChunkLoading;
-		N5S3OMEZarrImageLoader imageLoader = new N5S3OMEZarrImageLoader( serviceEndpoint, signingRegion, bucketName, key, S3CredentialsCreator.S3Authentication.Anonymous );
+		N5S3OMEZarrImageLoader imageLoader = new N5S3OMEZarrImageLoader( serviceEndpoint, signingRegion, bucketName, key );
 		SpimData spimData = new SpimData( null, Cast.unchecked( imageLoader.getSequenceDescription() ), imageLoader.getViewRegistrations() );
 		return spimData;
 	}


### PR DESCRIPTION
- can read from private s3 buckets now
- got rid of the s3 authentication mode; so `Authentication` is not necessary in the `bdv.n5.xml` any more (cc @K-Meech)

Needs https://github.com/tischi/imagej-utils/pull/46