### PR TITLE
Loading columns

### DIFF
--- a/src/main/java/de/embl/cba/mobie/MoBIE.java
+++ b/src/main/java/de/embl/cba/mobie/MoBIE.java
@@ -251,9 +251,21 @@ public class MoBIE
 		}
 	}
 
+	private String getRelativeTableLocation( SegmentationSource source ) {
+		return source.tableData.get( TableDataFormat.TabDelimitedFile ).relativePath;
+	}
+
+	public String getTablesDirectoryPath( SegmentationSource source ) {
+		return getTablesDirectoryPath( getRelativeTableLocation( source ) );
+	}
+
+	public String getTablesDirectoryPath( String relativeTableLocation ) {
+		return FileAndUrlUtils.combinePath( tableRoot, getDatasetName(), relativeTableLocation );
+	}
+
 	public String getDefaultTablePath( SegmentationSource source )
 	{
-		return getTablePath( source.tableData.get( TableDataFormat.TabDelimitedFile ).relativePath, "default.tsv" );
+		return getTablePath( getRelativeTableLocation( source ), "default.tsv" );
 	}
 
 	public String getDefaultTablePath( String relativeTableLocation )

--- a/src/main/java/de/embl/cba/mobie/Utils.java
+++ b/src/main/java/de/embl/cba/mobie/Utils.java
@@ -30,7 +30,7 @@ public abstract class Utils
 		FileSystem
 	}
 
-	private static String chooseCommonFileName( ArrayList<String> directories, String objectName ) {
+	private static String chooseCommonFileName( List<String> directories, String objectName ) {
 		Map<String, Integer> fileNameCounts = new HashMap<>();
 		ArrayList<String> commonFileNames = new ArrayList<>();
 
@@ -72,12 +72,10 @@ public abstract class Utils
 		return FileLocation.valueOf(gd.getNextChoice());
 	}
 
-	public static ArrayList<String> selectPathsFromProject( ArrayList<String> directories, String objectName ) {
+	public static String selectCommonFileNameFromProject( List<String> directories, String objectName ) {
 		if ( directories == null ) {
 			return null;
 		}
-
-		ArrayList<String> paths = null;
 
 		String fileName;
 		if ( directories.size() > 1) {
@@ -88,15 +86,22 @@ public abstract class Utils
 			String[] fileNames = FileAndUrlUtils.getFileNames( directories.get(0) );
 			fileName = selectionDialog( fileNames, objectName );
 		}
-		if ( fileName != null ) {
-			paths = new ArrayList<>();
-			for ( String directory: directories ) {
-				paths.add( FileAndUrlUtils.combinePath( directory, fileName ) );
-			}
+
+		return fileName;
+	}
+
+	public static String selectPathFromProject( String directory, String objectName ) {
+		if ( directory == null ) {
+			return null;
 		}
 
-		return paths;
-
+		String[] fileNames = FileAndUrlUtils.getFileNames( directory );
+		String fileName = selectionDialog( fileNames, objectName );
+		if ( fileName != null ) {
+			return FileAndUrlUtils.combinePath( directory, fileName );
+		} else {
+			return null;
+		}
 	}
 
 	// objectName is used for the dialog labels e.g. 'table', 'bookmark' etc...

--- a/src/main/java/de/embl/cba/mobie/Utils.java
+++ b/src/main/java/de/embl/cba/mobie/Utils.java
@@ -4,12 +4,13 @@ import bdv.util.BdvHandle;
 import bdv.viewer.Source;
 import bdv.viewer.SourceAndConverter;
 import de.embl.cba.bdv.utils.BdvUtils;
-import de.embl.cba.tables.FileUtils;
+import de.embl.cba.tables.FileAndUrlUtils;
 import de.embl.cba.tables.TableColumns;
 import de.embl.cba.tables.imagesegment.SegmentProperty;
 import de.embl.cba.tables.imagesegment.SegmentUtils;
 import de.embl.cba.tables.tablerow.TableRowImageSegment;
 import ij.IJ;
+import ij.gui.GenericDialog;
 import net.imglib2.*;
 import net.imglib2.realtransform.AffineTransform3D;
 import net.imglib2.realtransform.Scale3D;
@@ -23,6 +24,51 @@ import static de.embl.cba.bdv.utils.BdvUtils.getBdvWindowCenter;
 
 public abstract class Utils
 {
+	public enum FileLocation {
+		Project,
+		FileSystem
+	}
+
+	// objectName is used for the dialog labels e.g. 'table', 'bookmark' etc...
+	public static String selectPathFromProjectOrFileSystem (String directory, String objectName) throws IOException {
+		if (directory != null) {
+			final GenericDialog gd = new GenericDialog("Choose source");
+			gd.addChoice("Load from", new String[]{FileLocation.Project.toString(),
+					FileLocation.FileSystem.toString()}, FileLocation.Project.toString());
+			gd.showDialog();
+			if (gd.wasCanceled()) return null;
+			FileLocation fileLocation = FileLocation.valueOf(gd.getNextChoice());
+
+			if (fileLocation == FileLocation.Project) {
+				return FileAndUrlUtils.selectPath(directory, objectName);
+			} else {
+				return FileAndUrlUtils.selectPath(System.getProperty("user.home"), objectName);
+			}
+		} else {
+			return null;
+		}
+	}
+
+	// objectName is used for the dialog labels e.g. 'table', 'bookmark' etc...
+	public static String selectPathFromProjectOrFileSystem ( String[] directories, String objectName) throws IOException {
+		if ( directories != null) {
+			final GenericDialog gd = new GenericDialog("Choose source");
+			gd.addChoice("Load from", new String[]{FileLocation.Project.toString(),
+					FileLocation.FileSystem.toString()}, FileLocation.Project.toString());
+			gd.showDialog();
+			if (gd.wasCanceled()) return null;
+			FileLocation fileLocation = FileLocation.valueOf(gd.getNextChoice());
+
+			if (fileLocation == FileLocation.Project) {
+				return FileAndUrlUtils.selectPath(directory, objectName);
+			} else {
+				return FileAndUrlUtils.selectPath(System.getProperty("user.home"), objectName);
+			}
+		} else {
+			return null;
+		}
+	}
+
 	public static < T > SourceAndConverter< T > getSource( List< SourceAndConverter< T > > sourceAndConverters, String name )
 	{
 		for ( SourceAndConverter< T > sourceAndConverter : sourceAndConverters )
@@ -79,9 +125,9 @@ public abstract class Utils
 	public static String resolveTablePath( String tablePath )
 	{
 		if ( tablePath.startsWith( "http" ) ) {
-			tablePath = FileUtils.resolveTableURL( URI.create(tablePath) );
+			tablePath = FileAndUrlUtils.resolveTableURL( URI.create(tablePath) );
 		} else {
-			tablePath = FileUtils.resolveTablePath( tablePath );
+			tablePath = FileAndUrlUtils.resolveTablePath( tablePath );
 		}
 		return tablePath;
 	}

--- a/src/main/java/de/embl/cba/mobie/grid/GridOverlaySourceDisplay.java
+++ b/src/main/java/de/embl/cba/mobie/grid/GridOverlaySourceDisplay.java
@@ -50,7 +50,9 @@ public class GridOverlaySourceDisplay extends SourceDisplay implements ColoringL
 		selectionModel = new DefaultSelectionModel< DefaultAnnotatedIntervalTableRow >();
 		coloringModel.setSelectionModel( selectionModel );
 
-		tableViewer = new TableViewer<>( tableRows, selectionModel, coloringModel, name, tableDataFolder ).show();
+		ArrayList<String> tableDirectories = new ArrayList<>();
+		tableDirectories.add( moBIE.getTablesDirectoryPath( tableDataFolder ) );
+		tableViewer = new TableViewer<>( tableRows, selectionModel, coloringModel, name, tableDirectories ).show();
 		coloringModel.listeners().add( tableViewer );
 		selectionModel.listeners().add( tableViewer );
 

--- a/src/main/java/de/embl/cba/mobie/grid/GridOverlaySourceDisplay.java
+++ b/src/main/java/de/embl/cba/mobie/grid/GridOverlaySourceDisplay.java
@@ -33,12 +33,12 @@ public class GridOverlaySourceDisplay extends SourceDisplay implements ColoringL
 	private final String name;
 
 	// TODO: split in two classes: the GridOverlayDisplay and the GridOverlayView
-	public GridOverlaySourceDisplay(MoBIE moBIE2, BdvHandle bdvHandle, String name, String tableDataFolder, GridSourceTransformer sourceTransformer )
+	public GridOverlaySourceDisplay(MoBIE moBIE, BdvHandle bdvHandle, String name, String tableDataFolder, GridSourceTransformer sourceTransformer )
 	{
 		this.bdvHandle = bdvHandle;
 		this.name = name;
 
-		String tablePath = moBIE2.getDefaultTablePath( tableDataFolder );
+		String tablePath = moBIE.getDefaultTablePath( tableDataFolder );
 		tablePath = Utils.resolveTablePath( tablePath );
 		Logger.log( "Opening table:\n" + tablePath );
 
@@ -50,7 +50,7 @@ public class GridOverlaySourceDisplay extends SourceDisplay implements ColoringL
 		selectionModel = new DefaultSelectionModel< DefaultAnnotatedIntervalTableRow >();
 		coloringModel.setSelectionModel( selectionModel );
 
-		tableViewer = new TableViewer<>( tableRows, selectionModel, coloringModel, name ).show();
+		tableViewer = new TableViewer<>( tableRows, selectionModel, coloringModel, name, tableDataFolder ).show();
 		coloringModel.listeners().add( tableViewer );
 		selectionModel.listeners().add( tableViewer );
 

--- a/src/main/java/de/embl/cba/mobie/grid/GridOverlaySourceDisplay.java
+++ b/src/main/java/de/embl/cba/mobie/grid/GridOverlaySourceDisplay.java
@@ -54,7 +54,7 @@ public class GridOverlaySourceDisplay extends SourceDisplay implements ColoringL
 
 		ArrayList<String> tableDirectories = new ArrayList<>();
 		tableDirectories.add( moBIE.getTablesDirectoryPath( tableDataFolder ) );
-		tableViewer = new TableViewer<>( tableRows, selectionModel, coloringModel, name, tableDirectories ).show();
+		tableViewer = new TableViewer<>( moBIE, tableRows, selectionModel, coloringModel, name, tableDirectories ).show();
 		coloringModel.listeners().add( tableViewer );
 		selectionModel.listeners().add( tableViewer );
 

--- a/src/main/java/de/embl/cba/mobie/projectcreator/DatasetJsonCreator.java
+++ b/src/main/java/de/embl/cba/mobie/projectcreator/DatasetJsonCreator.java
@@ -17,6 +17,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
+import static de.embl.cba.mobie.projectcreator.ProjectCreatorHelper.imageFormatToFolderName;
+
 public class DatasetJsonCreator {
 
     ProjectCreator projectCreator;
@@ -73,7 +75,8 @@ public class DatasetJsonCreator {
 
                 imageDataLocations = new HashMap<>();
                 imageStorageLocation = new StorageLocation();
-                imageStorageLocation.relativePath = "images/local/" + imageName + ".xml";
+                imageStorageLocation.relativePath = "images/" + imageFormatToFolderName( ImageDataFormat.BdvN5) +
+                        "/" + imageName + ".xml";
                 imageDataLocations.put( ImageDataFormat.BdvN5, imageStorageLocation );
                 segmentationSource.imageData = imageDataLocations;
 
@@ -86,7 +89,8 @@ public class DatasetJsonCreator {
                 ImageSource imageSource = new ImageSource();
                 imageDataLocations = new HashMap<>();
                 imageStorageLocation = new StorageLocation();
-                imageStorageLocation.relativePath = "images/local/" + imageName + ".xml";
+                imageStorageLocation.relativePath = "images/" + imageFormatToFolderName( ImageDataFormat.BdvN5) +
+                        "/" + imageName + ".xml";
                 imageDataLocations.put( ImageDataFormat.BdvN5, imageStorageLocation );
                 imageSource.imageData = imageDataLocations;
 
@@ -105,7 +109,7 @@ public class DatasetJsonCreator {
 
     private void addNewDefaultView( Dataset dataset, String imageName, ProjectCreator.ImageType imageType ) {
 
-        View view = createView( imageName, imageType, "views", true );
+        View view = createView( imageName, imageType, "bookmark", true );
         dataset.views.put( "default", view );
     }
 

--- a/src/main/java/de/embl/cba/mobie/projectcreator/DatasetsCreator.java
+++ b/src/main/java/de/embl/cba/mobie/projectcreator/DatasetsCreator.java
@@ -1,12 +1,15 @@
 package de.embl.cba.mobie.projectcreator;
 
 import de.embl.cba.mobie.serialize.ProjectJsonParser;
+import de.embl.cba.mobie.source.ImageDataFormat;
 import de.embl.cba.tables.FileAndUrlUtils;
 import ij.IJ;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+
+import static de.embl.cba.mobie.projectcreator.ProjectCreatorHelper.imageFormatToFolderName;
 
 public class DatasetsCreator {
 
@@ -30,8 +33,10 @@ public class DatasetsCreator {
                 new File(datasetDir, "images").mkdirs();
                 new File(datasetDir, "misc").mkdirs();
                 new File(datasetDir, "tables").mkdirs();
-                new File(FileAndUrlUtils.combinePath(datasetDir.getAbsolutePath(), "images", "local")).mkdirs();
-                new File(FileAndUrlUtils.combinePath(datasetDir.getAbsolutePath(), "images", "remote")).mkdirs();
+                new File(FileAndUrlUtils.combinePath(datasetDir.getAbsolutePath(), "images",
+                        imageFormatToFolderName( ImageDataFormat.BdvN5 ))).mkdirs();
+                new File(FileAndUrlUtils.combinePath(datasetDir.getAbsolutePath(), "images",
+                        imageFormatToFolderName( ImageDataFormat.BdvN5S3 ))).mkdirs();
                 new File(FileAndUrlUtils.combinePath(datasetDir.getAbsolutePath(), "misc", "views")).mkdirs();
 
 

--- a/src/main/java/de/embl/cba/mobie/projectcreator/ImagesCreator.java
+++ b/src/main/java/de/embl/cba/mobie/projectcreator/ImagesCreator.java
@@ -54,12 +54,12 @@ public class ImagesCreator {
 
     private String getDefaultLocalImageXmlPath( String datasetName, String imageName ) {
         return FileAndUrlUtils.combinePath(projectCreator.getDataLocation().getAbsolutePath(), datasetName,
-                "images", "local", imageName + ".xml");
+                "images", imageFormatToFolderName( ImageDataFormat.BdvN5 ), imageName + ".xml");
     }
 
     private String getDefaultLocalImageDirPath( String datasetName ) {
         return FileAndUrlUtils.combinePath(projectCreator.getDataLocation().getAbsolutePath(), datasetName,
-                "images", "local" );
+                "images", imageFormatToFolderName( ImageDataFormat.BdvN5 ) );
     }
 
     private String getDefaultTableDirPath( String datasetName, String imageName ) {

--- a/src/main/java/de/embl/cba/mobie/projectcreator/ProjectCreatorHelper.java
+++ b/src/main/java/de/embl/cba/mobie/projectcreator/ProjectCreatorHelper.java
@@ -250,4 +250,8 @@ public class ProjectCreatorHelper {
             return null;
         }
     }
+
+    public static String imageFormatToFolderName( ImageDataFormat imageFormat ) {
+        return imageFormat.toString().replaceAll("\\.", "-");
+    }
 }

--- a/src/main/java/de/embl/cba/mobie/projectcreator/RemoteMetadataCreator.java
+++ b/src/main/java/de/embl/cba/mobie/projectcreator/RemoteMetadataCreator.java
@@ -24,6 +24,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import static de.embl.cba.mobie.projectcreator.ProjectCreatorHelper.getImageLocationFromSpimDataMinimal;
+import static de.embl.cba.mobie.projectcreator.ProjectCreatorHelper.imageFormatToFolderName;
 
 public class RemoteMetadataCreator {
     ProjectCreator projectCreator;
@@ -129,7 +130,7 @@ public class RemoteMetadataCreator {
         deleteRemoteMetadataForImage( datasetName, imageName );
 
         String remoteXmlLocation = FileAndUrlUtils.combinePath( projectCreator.getDataLocation().getAbsolutePath(),
-                datasetName, "images", "remote" );
+                datasetName, "images", imageFormatToFolderName( ImageDataFormat.BdvN5S3) );
 
         SpimDataMinimal spimDataMinimal = new XmlIoSpimDataMinimal().load( localXmlLocation );
         spimDataMinimal.setBasePath( new File( remoteXmlLocation ) );
@@ -138,7 +139,7 @@ public class RemoteMetadataCreator {
                 ImageDataFormat.BdvN5S3 );
 
         StorageLocation storageLocation = new StorageLocation();
-        storageLocation.relativePath = "images/remote/" + imageName + ".xml";
+        storageLocation.relativePath = "images/" + imageFormatToFolderName( ImageDataFormat.BdvN5S3 ) + "/" + imageName + ".xml";
         imageSource.imageData.put( ImageDataFormat.BdvN5S3, storageLocation );
 
     }

--- a/src/main/java/de/embl/cba/mobie/table/TableViewer.java
+++ b/src/main/java/de/embl/cba/mobie/table/TableViewer.java
@@ -60,7 +60,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static de.embl.cba.tables.FileUtils.selectPathFromProjectOrFileSystem;
+import static de.embl.cba.mobie.Utils.createAnnotatedImageSegmentsFromTableFile;
+import static de.embl.cba.mobie.Utils.selectPathFromProjectOrFileSystem;
 import static de.embl.cba.tables.color.CategoryTableRowColumnColoringModel.DARK_GREY;
 import static de.embl.cba.tables.tablerow.TableRows.setTableCell;
 
@@ -102,7 +103,7 @@ public class TableViewer< T extends TableRow > implements SelectionListener< T >
 			final List< T > tableRows,
 			final SelectionModel< T > selectionModel,
 			final MoBIEColoringModel< T > moBIEColoringModel,
-			String tableName )
+			String tableName, String tablesDirectory )
 	{
 		this.tableRows = tableRows;
 		this.coloringModel = moBIEColoringModel;
@@ -110,6 +111,7 @@ public class TableViewer< T extends TableRow > implements SelectionListener< T >
 		this.tableName = tableName;
 		this.recentlySelectedRowInView = -1;
 		this.additionalTables = new ArrayList<>();
+		this.tablesDirectory = tablesDirectory;
 
 		// TODO: reconsider
 		registerAsTableRowListener( tableRows );

--- a/src/main/java/de/embl/cba/mobie/ui/SwingHelper.java
+++ b/src/main/java/de/embl/cba/mobie/ui/SwingHelper.java
@@ -1,6 +1,7 @@
 package de.embl.cba.mobie.ui;
 
 import de.embl.cba.mobie.MoBIE;
+import ij.gui.GenericDialog;
 
 import javax.swing.*;
 import java.awt.*;
@@ -54,6 +55,17 @@ public class SwingHelper
 		comboBox.setPrototypeDisplayValue( MoBIE.PROTOTYPE_DISPLAY_VALUE );
 		comboBox.setPreferredSize( new Dimension( COMBOBOX_WIDTH, 20 ) );
 		comboBox.setMaximumSize( new Dimension( COMBOBOX_WIDTH, 20 ) );
+	}
+
+	public static String selectionDialog( String[] choices, String objectName ) {
+		final GenericDialog gd = new GenericDialog("Choose " + objectName );
+		gd.addChoice( objectName, choices, choices[0] );
+		gd.showDialog();
+		if (gd.wasCanceled()) {
+			return null;
+		} else {
+			return gd.getNextChoice();
+		}
 	}
 
 }

--- a/src/main/java/de/embl/cba/mobie/ui/UserInterfaceHelper.java
+++ b/src/main/java/de/embl/cba/mobie/ui/UserInterfaceHelper.java
@@ -55,15 +55,15 @@ public class UserInterfaceHelper
 	private static final String ADD = "view";
 	public static final int SPACING = 20;
 
-	private final MoBIE moBIE2;
+	private final MoBIE moBIE;
 	private int viewsSelectionPanelHeight;
 	private JPanel viewSelectionPanel;
 	private Map< String, Map< String, View > > groupingsToViews;
 	private Map< String, JComboBox > groupingsToComboBox;
 
-	public UserInterfaceHelper( MoBIE moBIE2 )
+	public UserInterfaceHelper( MoBIE moBIE )
 	{
-		this.moBIE2 = moBIE2;
+		this.moBIE = moBIE;
 	}
 
 	public static JPanel createDisplaySettingsPanel()
@@ -264,7 +264,7 @@ public class UserInterfaceHelper
 		final JPanel panel = new JPanel();
 		panel.setLayout( new BoxLayout( panel, BoxLayout.Y_AXIS ) );
 
-		panel.add( createInfoPanel( moBIE2.getSettings().values.getProjectLocation(), moBIE2.getSettings().values.getPublicationURL() ) );
+		panel.add( createInfoPanel( moBIE.getSettings().values.getProjectLocation(), moBIE.getSettings().values.getPublicationURL() ) );
 		panel.add( new JSeparator( SwingConstants.HORIZONTAL ) );
 		panel.add( createDatasetSelectionPanel() );
 		panel.add( new JSeparator( SwingConstants.HORIZONTAL ) );
@@ -347,7 +347,7 @@ public class UserInterfaceHelper
 
 	public JPanel createViewsSelectionPanel( )
 	{
-		final Map< String, View > views = moBIE2.getViews();
+		final Map< String, View > views = moBIE.getViews();
 
 		groupingsToViews = new HashMap<>(  );
 		groupingsToComboBox = new HashMap<>( );
@@ -381,7 +381,7 @@ public class UserInterfaceHelper
 		// If it's the first time, just add all the panels in order
 		if ( groupingsToComboBox.keySet().size() == 0 ) {
 			for (String uiSelectionGroup : uiSelectionGroups) {
-				final JPanel selectionPanel = createViewSelectionPanel(moBIE2, uiSelectionGroup, groupingsToViews.get(uiSelectionGroup));
+				final JPanel selectionPanel = createViewSelectionPanel(moBIE, uiSelectionGroup, groupingsToViews.get(uiSelectionGroup));
 				viewSelectionPanel.add(selectionPanel);
 			}
 		} else {
@@ -392,7 +392,7 @@ public class UserInterfaceHelper
 				if ( groupingsToComboBox.containsKey( uiSelectionGroup ) ) {
 					groupingsToComboBox.get( uiSelectionGroup ).addItem( viewName );
 				} else {
-					final JPanel selectionPanel = createViewSelectionPanel(moBIE2, uiSelectionGroup, groupingsToViews.get(uiSelectionGroup));
+					final JPanel selectionPanel = createViewSelectionPanel(moBIE, uiSelectionGroup, groupingsToViews.get(uiSelectionGroup));
 					int alphabeticalIndex = uiSelectionGroups.indexOf( uiSelectionGroup );
 					indexToPanel.put( alphabeticalIndex, selectionPanel );
 				}
@@ -425,7 +425,7 @@ public class UserInterfaceHelper
 		return groupingsToViews.keySet();
 	}
 
-	private JPanel createViewSelectionPanel(MoBIE moBIE2, String panelName, Map< String, View > views )
+	private JPanel createViewSelectionPanel(MoBIE moBIE, String panelName, Map< String, View > views )
 	{
 		final JPanel horizontalLayoutPanel = SwingUtils.horizontalLayoutPanel();
 
@@ -440,7 +440,7 @@ public class UserInterfaceHelper
 				{
 					final String viewName = ( String ) comboBox.getSelectedItem();
 					final View view = views.get( viewName );
-					moBIE2.getViewerManager().show( view );
+					moBIE.getViewerManager().show( view );
 				}).start();
 			} );
 		} );
@@ -482,7 +482,7 @@ public class UserInterfaceHelper
 //			Utils.logVector( "New reference normal vector (default): ", levelingVector );
 //		} );
 
-		button.addActionListener( e -> BdvUtils.levelCurrentView( moBIE2.getViewerManager().getSliceViewer().getBdvHandle(), targetNormalVector ) );
+		button.addActionListener( e -> BdvUtils.levelCurrentView( moBIE.getViewerManager().getSliceViewer().getBdvHandle(), targetNormalVector ) );
 
 		return horizontalLayoutPanel;
 	}
@@ -495,7 +495,7 @@ public class UserInterfaceHelper
 		final JTextField jTextField = new JTextField( "120.5,115.3,201.5" );
 		jTextField.setPreferredSize( new Dimension( COMBOBOX_WIDTH - 3, TEXT_FIELD_HEIGHT ) );
 		jTextField.setMaximumSize( new Dimension( COMBOBOX_WIDTH - 3, TEXT_FIELD_HEIGHT ) );
-		button.addActionListener( e -> BdvLocationChanger.moveToLocation( moBIE2.getViewerManager().getSliceViewer().getBdvHandle(), new BdvLocation( jTextField.getText() ) ) );
+		button.addActionListener( e -> BdvLocationChanger.moveToLocation( moBIE.getViewerManager().getSliceViewer().getBdvHandle(), new BdvLocation( jTextField.getText() ) ) );
 
 		horizontalLayoutPanel.add( getJLabel( "location" ) );
 		horizontalLayoutPanel.add( jTextField );
@@ -544,7 +544,7 @@ public class UserInterfaceHelper
 	{
 		final JPanel panel = SwingUtils.horizontalLayoutPanel();
 
-		final JComboBox< String > comboBox = new JComboBox<>( moBIE2.getDatasets().toArray( new String[ 0 ] ) );
+		final JComboBox< String > comboBox = new JComboBox<>( moBIE.getDatasets().toArray( new String[ 0 ] ) );
 
 		final JButton button = createButton( ADD );
 		button.addActionListener( e ->
@@ -552,11 +552,11 @@ public class UserInterfaceHelper
 			SwingUtilities.invokeLater( () ->
 			{
 				final String dataset = ( String ) comboBox.getSelectedItem();
-				moBIE2.setDataset( dataset );
+				moBIE.setDataset( dataset );
 			} );
 		} );
 
-		comboBox.setSelectedItem( moBIE2.getDatasetName() );
+		comboBox.setSelectedItem( moBIE.getDatasetName() );
 		setComboBoxDimensions( comboBox );
 
 		panel.add( getJLabel( "dataset" ) );
@@ -811,7 +811,7 @@ public class UserInterfaceHelper
 
 		removeButton.addActionListener( e ->
 		{
-			moBIE2.getViewerManager().removeSourceDisplay( sourceDisplay );
+			moBIE.getViewerManager().removeSourceDisplay( sourceDisplay );
 		} );
 
 		return removeButton;

--- a/src/main/java/de/embl/cba/mobie/view/ViewerManager.java
+++ b/src/main/java/de/embl/cba/mobie/view/ViewerManager.java
@@ -79,14 +79,8 @@ public class ViewerManager
 
 	public void initTableViewer( SegmentationSourceDisplay display  )
 	{
-		ArrayList<String> tablesDirectories = new ArrayList<>();
-		for ( String source: display.getSources() ) {
-			SegmentationSource segmentationSource = (SegmentationSource) moBIE.getSource( source );
-			tablesDirectories.add( moBIE.getTablesDirectoryPath( segmentationSource ) );
-		}
-
 		display.tableViewer = new TableViewer<>( moBIE, display.segments, display.selectionModel, display.coloringModel,
-				display.getName(), tablesDirectories ).show();
+				display.getName(), display.getSources() ).show();
 		display.selectionModel.listeners().add( display.tableViewer );
 		display.coloringModel.listeners().add( display.tableViewer );
 	}

--- a/src/main/java/de/embl/cba/mobie/view/ViewerManager.java
+++ b/src/main/java/de/embl/cba/mobie/view/ViewerManager.java
@@ -120,7 +120,12 @@ public class ViewerManager
 			if ( sourceDisplay instanceof ImageSourceDisplay ) {
 				currentDisplay = new ImageSourceDisplay( (ImageSourceDisplay) sourceDisplay );
 			} else if ( sourceDisplay instanceof  SegmentationSourceDisplay ) {
-				currentDisplay = new SegmentationSourceDisplay( (SegmentationSourceDisplay) sourceDisplay );
+				SegmentationSourceDisplay segmentationSourceDisplay = (SegmentationSourceDisplay) sourceDisplay;
+				if ( segmentationSourceDisplay.tableViewer.hasColumnsFromTablesOutsideProject() ) {
+					IJ.log( "Cannot make a view with tables that have columns loaded from the filesystem (not within the project).");
+					return null;
+				}
+				currentDisplay = new SegmentationSourceDisplay( segmentationSourceDisplay );
 			}
 
 			if ( currentDisplay != null ) {

--- a/src/main/java/de/embl/cba/mobie/view/ViewerManager.java
+++ b/src/main/java/de/embl/cba/mobie/view/ViewerManager.java
@@ -14,6 +14,7 @@ import de.embl.cba.mobie.segment.SegmentAdapter;
 import de.embl.cba.mobie.display.ImageSourceDisplay;
 import de.embl.cba.mobie.display.SegmentationSourceDisplay;
 import de.embl.cba.mobie.display.SourceDisplay;
+import de.embl.cba.mobie.source.SegmentationSource;
 import de.embl.cba.mobie.table.TableDataFormat;
 import de.embl.cba.mobie.table.TableViewer;
 import de.embl.cba.mobie.transform.*;
@@ -25,6 +26,7 @@ import de.embl.cba.mobie.volume.SegmentsVolumeView;
 import de.embl.cba.mobie.volume.UniverseManager;
 import de.embl.cba.tables.select.DefaultSelectionModel;
 import de.embl.cba.tables.tablerow.TableRowImageSegment;
+import ij.IJ;
 import net.imglib2.realtransform.AffineTransform3D;
 import sc.fiji.bdvpg.bdv.navigate.ViewerTransformAdjuster;
 
@@ -83,7 +85,7 @@ public class ViewerManager
 			tablesDirectories.add( moBIE.getTablesDirectoryPath( segmentationSource ) );
 		}
 
-		display.tableViewer = new TableViewer<>( display.segments, display.selectionModel, display.coloringModel,
+		display.tableViewer = new TableViewer<>( moBIE, display.segments, display.selectionModel, display.coloringModel,
 				display.getName(), tablesDirectories ).show();
 		display.selectionModel.listeners().add( display.tableViewer );
 		display.coloringModel.listeners().add( display.tableViewer );

--- a/src/main/java/de/embl/cba/mobie/view/ViewerManager.java
+++ b/src/main/java/de/embl/cba/mobie/view/ViewerManager.java
@@ -84,10 +84,14 @@ public class ViewerManager
 
 	public void initTableViewer( SegmentationSourceDisplay display  )
 	{
-		String tablesDirectory = ((SegmentationSource) moBIE.getSource( display.getSources().get(0) )).tableDataLocation;
+		ArrayList<String> tablesDirectories = new ArrayList<>();
+		for ( String source: display.getSources() ) {
+			SegmentationSource segmentationSource = (SegmentationSource) moBIE.getSource( source );
+			tablesDirectories.add( moBIE.getTablesDirectoryPath( segmentationSource ) );
+		}
 
 		display.tableViewer = new TableViewer<>( display.segments, display.selectionModel, display.coloringModel,
-				display.getName(), tablesDirectory ).show();
+				display.getName(), tablesDirectories ).show();
 		display.selectionModel.listeners().add( display.tableViewer );
 		display.coloringModel.listeners().add( display.tableViewer );
 	}

--- a/src/main/java/de/embl/cba/mobie/view/additionalviews/AdditionalViewsLoader.java
+++ b/src/main/java/de/embl/cba/mobie/view/additionalviews/AdditionalViewsLoader.java
@@ -9,28 +9,28 @@ import de.embl.cba.mobie.view.View;
 import java.io.IOException;
 import java.util.Map;
 
-import static de.embl.cba.tables.FileUtils.selectPathFromProjectOrFileSystem;
+import static de.embl.cba.mobie.Utils.selectPathFromProjectOrFileSystem;
 
 public class AdditionalViewsLoader {
 
-    private MoBIE moBIE2;
+    private MoBIE moBIE;
     private MoBIESettings settings;
 
-    public AdditionalViewsLoader ( MoBIE moBIE2 ) {
-        this.moBIE2 = moBIE2;
-        this.settings = moBIE2.getSettings();
+    public AdditionalViewsLoader ( MoBIE moBIE ) {
+        this.moBIE = moBIE;
+        this.settings = moBIE.getSettings();
     }
 
     public void loadAdditionalViewsDialog() {
         try {
-            String additionalViewsDirectory = moBIE2.getDatasetPath("misc", "views" );
+            String additionalViewsDirectory = moBIE.getDatasetPath("misc", "views" );
             String selectedFilePath = selectPathFromProjectOrFileSystem( additionalViewsDirectory, "View" );
             // to match to the existing view selection panels, we enable the cross platform look and feel
             UserInterfaceHelper.resetCrossPlatformSwingLookAndFeel();
 
             if (selectedFilePath != null) {
                 Map< String, View> views = new AdditionalViewsJsonParser().getViews( selectedFilePath ).views;
-                moBIE2.getUserInterface().addViews( views );
+                moBIE.getUserInterface().addViews( views );
             }
 
             UserInterfaceHelper.resetSystemSwingLookAndFeel();

--- a/src/main/java/de/embl/cba/mobie/view/additionalviews/AdditionalViewsLoader.java
+++ b/src/main/java/de/embl/cba/mobie/view/additionalviews/AdditionalViewsLoader.java
@@ -10,7 +10,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Map;
 
-import static de.embl.cba.mobie.Utils.selectPathsFromProject;
+import static de.embl.cba.mobie.Utils.selectPathFromProject;
 
 public class AdditionalViewsLoader {
 
@@ -24,10 +24,7 @@ public class AdditionalViewsLoader {
 
     public void loadAdditionalViewsDialog() {
         try {
-            ArrayList<String> directories = new ArrayList<>();
-            directories.add( moBIE.getDatasetPath("misc", "views" ) );
-
-            String selectedFilePath = selectPathsFromProject( directories, "View" ).get(0);
+            String selectedFilePath = selectPathFromProject( moBIE.getDatasetPath("misc", "views" ), "View" );
             // to match to the existing view selection panels, we enable the cross platform look and feel
             UserInterfaceHelper.resetCrossPlatformSwingLookAndFeel();
 

--- a/src/main/java/de/embl/cba/mobie/view/additionalviews/AdditionalViewsLoader.java
+++ b/src/main/java/de/embl/cba/mobie/view/additionalviews/AdditionalViewsLoader.java
@@ -7,9 +7,10 @@ import de.embl.cba.mobie.ui.UserInterfaceHelper;
 import de.embl.cba.mobie.view.View;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Map;
 
-import static de.embl.cba.mobie.Utils.selectPathFromProjectOrFileSystem;
+import static de.embl.cba.mobie.Utils.selectPathsFromProject;
 
 public class AdditionalViewsLoader {
 
@@ -23,8 +24,10 @@ public class AdditionalViewsLoader {
 
     public void loadAdditionalViewsDialog() {
         try {
-            String additionalViewsDirectory = moBIE.getDatasetPath("misc", "views" );
-            String selectedFilePath = selectPathFromProjectOrFileSystem( additionalViewsDirectory, "View" );
+            ArrayList<String> directories = new ArrayList<>();
+            directories.add( moBIE.getDatasetPath("misc", "views" ) );
+
+            String selectedFilePath = selectPathsFromProject( directories, "View" ).get(0);
             // to match to the existing view selection panels, we enable the cross platform look and feel
             UserInterfaceHelper.resetCrossPlatformSwingLookAndFeel();
 

--- a/src/main/java/de/embl/cba/mobie/view/saving/ViewSavingHelpers.java
+++ b/src/main/java/de/embl/cba/mobie/view/saving/ViewSavingHelpers.java
@@ -9,14 +9,14 @@ import de.embl.cba.tables.github.GitHubUtils;
 
 import java.io.IOException;
 
-import static de.embl.cba.tables.FileUtils.isGithub;
+import static de.embl.cba.tables.github.GitHubUtils.isGithub;
 
 public class ViewSavingHelpers {
     public static void writeDatasetJson( Dataset dataset, View view, String viewName, String datasetJsonPath ) throws IOException {
         if ( viewName != null ) {
             dataset.views.put(viewName, view);
 
-            if (isGithub(datasetJsonPath)) {
+            if ( isGithub(datasetJsonPath)) {
                 new ViewsGithubWriter(GitHubUtils.rawUrlToGitLocation(datasetJsonPath)).writeViewToDatasetJson(viewName, view);
             } else {
                 new DatasetJsonParser().saveDataset(dataset, datasetJsonPath);

--- a/src/main/java/de/embl/cba/mobie/view/saving/ViewsSaver.java
+++ b/src/main/java/de/embl/cba/mobie/view/saving/ViewsSaver.java
@@ -99,10 +99,12 @@ public class ViewsSaver {
             }
 
             View currentView = moBIE.getViewerManager().getCurrentView(uiSelectionGroup, exclusive, includeViewerTransform);
-            try {
-                saveToAdditionalViewsJson( currentView, jsonPath );
-            } catch (IOException e) {
-                e.printStackTrace();
+            if ( currentView != null ) {
+                try {
+                    saveToAdditionalViewsJson(currentView, jsonPath);
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
             }
         }
     }
@@ -116,17 +118,19 @@ public class ViewsSaver {
             if (projectSaveLocation != null) {
                 View currentView = moBIE.getViewerManager().getCurrentView(uiSelectionGroup, exclusive, includeViewerTransform);
 
-                try {
-                    if (projectSaveLocation == ProjectSaveLocation.datasetJson) {
-                        saveToDatasetJson( currentView );
-                    } else {
-                        String viewJsonPath = chooseAdditionalViewsJson();
-                        if (viewJsonPath != null) {
-                            saveToAdditionalViewsJson( currentView, viewJsonPath );
+                if ( currentView != null ) {
+                    try {
+                        if (projectSaveLocation == ProjectSaveLocation.datasetJson) {
+                            saveToDatasetJson(currentView);
+                        } else {
+                            String viewJsonPath = chooseAdditionalViewsJson();
+                            if (viewJsonPath != null) {
+                                saveToAdditionalViewsJson(currentView, viewJsonPath);
+                            }
                         }
+                    } catch (IOException e) {
+                        e.printStackTrace();
                     }
-                } catch (IOException e) {
-                    e.printStackTrace();
                 }
             }
         }

--- a/src/test/java/projects/OpenLocalCropTest.java
+++ b/src/test/java/projects/OpenLocalCropTest.java
@@ -12,6 +12,6 @@ public class OpenLocalCropTest
 	{
 		final ImageJ imageJ = new ImageJ();
 		imageJ.ui().showUI();
-		final MoBIE moBIE2 = new MoBIE("/g/emcf/pape/mobie-test-projects/mobie_crop", MoBIESettings.settings().imageDataStorageModality( MoBIESettings.ImageDataStorageModality.FileSystem ));
+		final MoBIE moBIE = new MoBIE("/g/emcf/pape/mobie-test-projects/mobie_crop", MoBIESettings.settings().imageDataStorageModality( MoBIESettings.ImageDataStorageModality.FileSystem ));
 	}
 }

--- a/src/test/java/projects/OpenLocalTestData.java
+++ b/src/test/java/projects/OpenLocalTestData.java
@@ -10,6 +10,6 @@ public class OpenLocalTestData
 	public static void main( String[] args ) throws IOException
 	{
 		final ImageJ imageJ = new ImageJ();
-		final MoBIE moBIE2 = new MoBIE("/g/kreshuk/pape/Work/data/mobie/full-example");
+		final MoBIE moBIE = new MoBIE("/g/kreshuk/pape/Work/data/mobie/full-example");
 	}
 }

--- a/src/test/java/projects/OpenRemoteZebrafish.java
+++ b/src/test/java/projects/OpenRemoteZebrafish.java
@@ -13,6 +13,6 @@ public class OpenRemoteZebrafish
 	{
 		final ImageJ imageJ = new ImageJ();
 		imageJ.ui().showUI();
-		new MoBIE("https://github.com/mobie/zebrafish-lm-datasets", MoBIESettings.settings().gitProjectBranch( "spec-v2" ).imageDataFormat( ImageDataFormat.BdvN5S3 ) );
+		new MoBIE("https://github.com/mobie/zebrafish-lm-datasets", MoBIESettings.settings().gitProjectBranch( "new-data-spec" ).imageDataFormat( ImageDataFormat.BdvN5S3 ) );
 	}
 }


### PR DESCRIPTION
Changes:
- Starts to implement loading extra columns on table
- renames remaining 'mobie2' references to 'mobie'
- stops view saving when columns are loaded from tables outside the project
- some minor project creator changes

@tischi Could you take a look? I'm running into an error with loading columns. e.g. if you open the remote zebrafish dataset, view any segmentation then load columns... from project, it errors with:
```
java.lang.IllegalArgumentException: Identifier not found
	at javax.swing.table.DefaultTableColumnModel.getColumnIndex(DefaultTableColumnModel.java:282)
	at de.embl.cba.tables.TableRows.setTableCell(TableRows.java:194)
	at de.embl.cba.mobie.table.TableViewer$1.cellChanged(TableViewer.java:156)
	at de.embl.cba.tables.tablerow.AbstractTableRow.lambda$notifyCellChangedListeners$0(AbstractTableRow.java:45)
	at java.lang.Thread.run(Thread.java:748)
```
Seems like there's some weird interaction with modifying the table after it has all its listeners instantiated...
Also, some refactoring will be needed to get this working for loading columns onto the grid table too.
(it might be quicker to just look through this together next week on zoom sometime?)

This also needs changes to imagej-utils (I'll put a draft PR on there in a minute)