### PR TITLE
use window centre for normalised affine

### DIFF
--- a/src/main/java/de/embl/cba/mobie/bdv/ViewerTransformLogger.java
+++ b/src/main/java/de/embl/cba/mobie/bdv/ViewerTransformLogger.java
@@ -39,7 +39,8 @@ public class ViewerTransformLogger implements BdvPlaygroundActionCommand
 			final AffineViewerTransform affineViewerTransform = new AffineViewerTransform( affineTransform3D.getRowPackedCopy(), timepoint );
 
 			// normalized affine
-			final AffineTransform3D normalisedViewerTransform = Utils.createNormalisedViewerTransform( bdv, Utils.getMousePosition( bdv ) );
+			final AffineTransform3D normalisedViewerTransform = Utils.createNormalisedViewerTransform( bdv,
+					PlaygroundUtils.getWindowCentreInPixelUnits( bdv ) );
 			final NormalizedAffineViewerTransform normalizedAffineViewerTransform = new NormalizedAffineViewerTransform( normalisedViewerTransform.getRowPackedCopy(), timepoint );
 
 			// print

--- a/src/main/java/de/embl/cba/mobie/view/ViewerManager.java
+++ b/src/main/java/de/embl/cba/mobie/view/ViewerManager.java
@@ -3,6 +3,7 @@ package de.embl.cba.mobie.view;
 import bdv.util.BdvHandle;
 import de.embl.cba.mobie.Constants;
 import de.embl.cba.mobie.MoBIE;
+import de.embl.cba.mobie.PlaygroundUtils;
 import de.embl.cba.mobie.Utils;
 import de.embl.cba.mobie.bdv.ImageSliceView;
 import de.embl.cba.mobie.bdv.SegmentationImageSliceView;
@@ -138,7 +139,8 @@ public class ViewerManager
 
 		if ( includeViewerTransform )
 		{
-			AffineTransform3D normalisedViewTransform = Utils.createNormalisedViewerTransform( bdvHandle, Utils.getMousePosition( bdvHandle ) );
+			AffineTransform3D normalisedViewTransform = Utils.createNormalisedViewerTransform( bdvHandle,
+					PlaygroundUtils.getWindowCentreInPixelUnits( bdvHandle ) );
 
 			final NormalizedAffineViewerTransform transform = new NormalizedAffineViewerTransform( normalisedViewTransform.getRowPackedCopy(), bdvHandle.getViewerPanel().state().getCurrentTimepoint() );
 			return new View(uiSelectionGroup, viewSourceDisplays, viewSourceTransforms, transform, isExclusive);


### PR DESCRIPTION
I found a couple of other places where we were still using ```Utils.getMousePosition()```. 
I think using the window centre for all the viewer transform stuff is more consistent.