### PR TITLE
fix platynereis bookmark issues

### DIFF
--- a/src/main/java/de/embl/cba/mobie/color/ColoringModelHelper.java
+++ b/src/main/java/de/embl/cba/mobie/color/ColoringModelHelper.java
@@ -17,7 +17,11 @@ public class ColoringModelHelper
 
 			String coloringLut = getColoringLut( segmentationDisplay );
 
-			coloringModel = modelCreator.createColoringModel( segmentationDisplay.getColorByColumn(), coloringLut, segmentationDisplay.getValueLimits()[ 0 ], segmentationDisplay.getValueLimits()[ 1 ] );
+			if ( segmentationDisplay.getValueLimits() != null ) {
+				coloringModel = modelCreator.createColoringModel(segmentationDisplay.getColorByColumn(), coloringLut, segmentationDisplay.getValueLimits()[0], segmentationDisplay.getValueLimits()[1]);
+			} else {
+				coloringModel = modelCreator.createColoringModel(segmentationDisplay.getColorByColumn(), coloringLut, null, null );
+			}
 
 			segmentationDisplay.coloringModel = new MoBIEColoringModel( coloringModel );
 		}


### PR DESCRIPTION
Fixes https://github.com/mobie/mobie-viewer-fiji/issues/264

Fixes errors when loading bookmarks that 'color by column' with a categorical lut. These don't need a min/max value limit in the view.