### PR TITLE
remember last selected dir

### DIFF
--- a/src/main/java/de/embl/cba/mobie/Utils.java
+++ b/src/main/java/de/embl/cba/mobie/Utils.java
@@ -4,6 +4,7 @@ import bdv.util.BdvHandle;
 import bdv.viewer.Source;
 import bdv.viewer.SourceAndConverter;
 import de.embl.cba.bdv.utils.BdvUtils;
+import de.embl.cba.mobie.view.View;
 import de.embl.cba.tables.FileAndUrlUtils;
 import de.embl.cba.tables.TableColumns;
 import de.embl.cba.tables.imagesegment.SegmentProperty;
@@ -14,6 +15,9 @@ import ij.gui.GenericDialog;
 import net.imglib2.*;
 import net.imglib2.realtransform.AffineTransform3D;
 import net.imglib2.realtransform.Scale3D;
+
+import javax.swing.*;
+import javax.swing.filechooser.FileNameExtensionFilter;
 import java.io.*;
 import java.net.URI;
 import java.util.*;
@@ -104,18 +108,52 @@ public abstract class Utils
 		}
 	}
 
+	public static File lastSelectedDir;
+
+	private static void setLastSelectedDir( String filePath ) {
+		File selectedFile = new File( filePath );
+		if ( selectedFile.isDirectory() ) {
+			lastSelectedDir = selectedFile;
+		} else {
+			lastSelectedDir = selectedFile.getParentFile();
+		}
+	}
+
 	// objectName is used for the dialog labels e.g. 'table', 'bookmark' etc...
-	public static String selectPathFromFileSystem ( String objectName )
+	public static String selectOpenPathFromFileSystem( String objectName, String fileExtension ) {
+		final JFileChooser jFileChooser = new JFileChooser( lastSelectedDir );
+		jFileChooser.setFileFilter(new FileNameExtensionFilter( fileExtension, fileExtension ));
+		return selectOpenPathFromFileSystem( objectName, jFileChooser );
+	}
+
+	public static String selectOpenPathFromFileSystem( String objectName ) {
+		final JFileChooser jFileChooser = new JFileChooser( lastSelectedDir );
+		return selectOpenPathFromFileSystem( objectName, jFileChooser );
+	}
+
+	public static String selectOpenPathFromFileSystem( String objectName, JFileChooser jFileChooser ) {
+		String filePath = null;
+		jFileChooser.setDialogTitle( "Select " + objectName );
+		if (jFileChooser.showOpenDialog(null) == JFileChooser.APPROVE_OPTION) {
+			filePath = jFileChooser.getSelectedFile().getAbsolutePath();
+			setLastSelectedDir( filePath );
+		}
+
+		return filePath;
+	}
+
+	// objectName is used for the dialog labels e.g. 'table', 'bookmark' etc...
+	public static String selectSavePathFromFileSystem( String fileExtension )
 	{
-		try
-		{
-			return FileAndUrlUtils.selectPath( System.getProperty("user.home"), objectName );
+		String filePath = null;
+		final JFileChooser jFileChooser = new JFileChooser( lastSelectedDir );
+		jFileChooser.setFileFilter(new FileNameExtensionFilter( fileExtension, fileExtension ));
+		if (jFileChooser.showSaveDialog(null) == JFileChooser.APPROVE_OPTION) {
+			filePath = jFileChooser.getSelectedFile().getAbsolutePath();
+			setLastSelectedDir( filePath );
 		}
-		catch ( IOException e )
-		{
-			e.printStackTrace();
-			throw new RuntimeException( "File not found: " + objectName );
-		}
+
+		return filePath;
 	}
 
 	public static < T > SourceAndConverter< T > getSource( List< SourceAndConverter< T > > sourceAndConverters, String name )

--- a/src/main/java/de/embl/cba/mobie/projectcreator/ui/ProjectsCreatorPanel.java
+++ b/src/main/java/de/embl/cba/mobie/projectcreator/ui/ProjectsCreatorPanel.java
@@ -3,6 +3,7 @@ package de.embl.cba.mobie.projectcreator.ui;
 import de.embl.cba.mobie.Dataset;
 import de.embl.cba.mobie.MoBIE;
 import de.embl.cba.mobie.Project;
+import de.embl.cba.mobie.Utils;
 import de.embl.cba.mobie.projectcreator.ProjectCreator;
 import de.embl.cba.mobie.source.ImageDataFormat;
 import de.embl.cba.tables.SwingUtils;
@@ -375,13 +376,10 @@ public class ProjectsCreatorPanel extends JFrame {
         String datasetName = (String) datasetComboBox.getSelectedItem();
 
         if (!datasetName.equals("")) {
+            String filePath = Utils.selectOpenPathFromFileSystem("bdv xml","xml" );
 
-            JFileChooser chooser = new JFileChooser();
-            chooser.setFileFilter(new FileNameExtensionFilter("xml", "xml"));
-            chooser.setDialogTitle( "Select bdv xml..." );
-            int returnVal = chooser.showOpenDialog(null );
-            if (returnVal == JFileChooser.APPROVE_OPTION) {
-                File xmlLocation = new File( chooser.getSelectedFile().getAbsolutePath() );
+            if ( filePath != null ) {
+                File xmlLocation = new File( filePath );
                 final GenericDialog gd = new GenericDialog("Add Bdv Format Image To Project...");
                 String[] addMethods = new String[]{ ProjectCreator.AddMethod.link.toString(),
                         ProjectCreator.AddMethod.copy.toString(), ProjectCreator.AddMethod.move.toString() };

--- a/src/main/java/de/embl/cba/mobie/table/TableViewer.java
+++ b/src/main/java/de/embl/cba/mobie/table/TableViewer.java
@@ -445,7 +445,7 @@ public class TableViewer< T extends TableRow > implements SelectionListener< T >
 
 	private void loadColumnsFromFileSystem()
 	{
-		String path = selectPathFromFileSystem( "Table" );
+		String path = selectOpenPathFromFileSystem( "Table" );
 
 		if ( path != null ) {
 			new Thread( () -> {

--- a/src/main/java/de/embl/cba/mobie/view/additionalviews/AdditionalViewsLoader.java
+++ b/src/main/java/de/embl/cba/mobie/view/additionalviews/AdditionalViewsLoader.java
@@ -8,7 +8,6 @@ import de.embl.cba.mobie.ui.UserInterfaceHelper;
 import de.embl.cba.mobie.view.View;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Map;
 
 import static de.embl.cba.mobie.Utils.*;
@@ -31,7 +30,7 @@ public class AdditionalViewsLoader {
             if ( fileLocation == Utils.FileLocation.Project ) {
                 selectedFilePath = selectPathFromProject( moBIE.getDatasetPath("misc", "views" ), "View" );
             } else {
-                selectedFilePath = selectPathFromFileSystem( "View" );
+                selectedFilePath = selectOpenPathFromFileSystem( "View" );
             }
 
             // to match to the existing view selection panels, we enable the cross platform look and feel

--- a/src/main/java/de/embl/cba/mobie/view/saving/ViewsSaver.java
+++ b/src/main/java/de/embl/cba/mobie/view/saving/ViewsSaver.java
@@ -18,6 +18,7 @@ import java.io.*;
 import java.util.Arrays;
 import java.util.HashMap;
 
+import static de.embl.cba.mobie.Utils.selectSavePathFromFileSystem;
 import static de.embl.cba.mobie.projectcreator.ProjectCreatorHelper.makeNewUiSelectionGroup;
 import static de.embl.cba.mobie.ui.UserInterfaceHelper.tidyString;
 import static de.embl.cba.mobie.view.saving.ViewSavingHelpers.writeAdditionalViewsJson;
@@ -86,12 +87,7 @@ public class ViewsSaver {
     }
 
     private void saveToFileSystem( String uiSelectionGroup, boolean exclusive, boolean includeViewerTransform ) {
-        String jsonPath = null;
-        final JFileChooser jFileChooser = new JFileChooser();
-        jFileChooser.setFileFilter(new FileNameExtensionFilter("json", "json"));
-        if (jFileChooser.showSaveDialog(null) == JFileChooser.APPROVE_OPTION) {
-            jsonPath = jFileChooser.getSelectedFile().getAbsolutePath();
-        }
+        String jsonPath = selectSavePathFromFileSystem( "json" );
 
         if (jsonPath != null) {
             if (!jsonPath.endsWith(".json")) {


### PR DESCRIPTION
Fixes https://github.com/mobie/mobie-viewer-fiji/issues/340

Makes all jfilechoosers remember the last selected directory on the filesystem e.g. when:
- saving additional views
- loading additional views
- loading additional tables