### PR TITLE
Keyboard shortcuts for the Annotator

### DIFF
--- a/src/main/java/de/embl/cba/mobie/annotate/AnnotatedIntervalCreator.java
+++ b/src/main/java/de/embl/cba/mobie/annotate/AnnotatedIntervalCreator.java
@@ -13,30 +13,27 @@ import java.util.stream.Collectors;
 
 public class AnnotatedIntervalCreator
 {
-	private final Map< String, List< String > > columns;
-	private final Map< String, List< String > > annotationIdToSources;
-	private final Function< String, SourceAndConverter< ? > > sourceAndConverterSupplier;
 	private List< AnnotatedIntervalTableRow > annotatedIntervalTableRows;
 
-	public AnnotatedIntervalCreator( Map< String, List< String > > columns, Map< String, List< String > > annotationIdToSources, Function< String, SourceAndConverter< ? > > sourceAndConverterSupplier)
-	{
-		this.columns = columns;
-		this.annotationIdToSources = annotationIdToSources;
-		this.sourceAndConverterSupplier = sourceAndConverterSupplier;
-		createAnnotatedIntervals();
-	}
-
-	private void createAnnotatedIntervals()
+	/**
+	 * For each annotation Id create one TableRow.
+	 *
+	 * @param columns
+	 * 					Columns containing the values for the table rows. The columns may contain more rows than annotation ids. Only the rows that are matching one of the annotation ids are used.
+	 * @param annotationIdToSourceNames
+	 * @param sourceAndConverterSupplier
+	 */
+	public AnnotatedIntervalCreator( Map< String, List< String > > columns, Map< String, List< String > > annotationIdToSourceNames, Function< String, SourceAndConverter< ? > > sourceAndConverterSupplier)
 	{
 		annotatedIntervalTableRows = new ArrayList<>();
-		final int numRows = columns.values().iterator().next().size();
-		final List< String > annotationIds = columns.get( "annotation_id" );
+		final List< String > annotationIdColumn = columns.get( "annotation_id" );
 
-		for ( int rowIndex = 0; rowIndex < numRows; rowIndex++ )
+		for ( String annotationId : annotationIdToSourceNames.keySet() )
 		{
-			final String annotationId = annotationIds.get( rowIndex );
-			final List< ? extends Source< ? > > sources = annotationIdToSources.get( annotationId ).stream().map( name -> sourceAndConverterSupplier.apply( name ).getSpimSource() ).collect( Collectors.toList() );
+			final List< ? extends Source< ? > > sources = annotationIdToSourceNames.get( annotationId ).stream().map( name -> sourceAndConverterSupplier.apply( name ).getSpimSource() ).collect( Collectors.toList() );
 			final RealInterval realInterval = TransformHelper.unionRealInterval( sources );
+
+			final int rowIndex = annotationIdColumn.indexOf( annotationId );
 
 			annotatedIntervalTableRows.add(
 					new DefaultAnnotatedIntervalTableRow(

--- a/src/main/java/de/embl/cba/mobie/display/AnnotatedIntervalDisplay.java
+++ b/src/main/java/de/embl/cba/mobie/display/AnnotatedIntervalDisplay.java
@@ -36,8 +36,6 @@ public class AnnotatedIntervalDisplay extends AnnotatedRegionDisplay< AnnotatedI
 		return sources;
 	}
 
-
-
 	public AnnotatedIntervalDisplay( String name, double opacity, Map< String, List< String > > sources, String lut, String colorByColumn, Double[] valueLimits, List< String > selectedSegmentIds, boolean showScatterPlot, String[] scatterPlotAxes, List< String > tables )
 	{
 		this.name = name;

--- a/src/main/java/de/embl/cba/mobie/ui/UserInterfaceHelper.java
+++ b/src/main/java/de/embl/cba/mobie/ui/UserInterfaceHelper.java
@@ -110,6 +110,7 @@ public class UserInterfaceHelper
 		minSlider.setNumColummns( 7 );
 		minSlider.setDecimalFormat( "####E0" );
 
+
 		final SliderPanelDouble maxSlider =
 				new SliderPanelDouble( "Max", max, spinnerStepSize );
 		maxSlider.setNumColummns( 7 );


### PR DESCRIPTION
see: https://github.com/mobie/mobie-viewer-fiji/issues/352

@K-Meech 

I added back the code that was in the ij-utils commit. It turns out that this commit was just adding the button but did not implement the actual keyboard listener. I vaguely remember that I had trouble getting this to work, because the annotator typically is not the focused window, because people click in the BDV window. We could implement a "global" keyboard listener, but then if people write an e-mail in between it would still listen...