### PR TITLE
Implement shared queue for OMEZarr

### DIFF
--- a/src/main/java/de/embl/cba/mobie/MoBIE.java
+++ b/src/main/java/de/embl/cba/mobie/MoBIE.java
@@ -1,5 +1,6 @@
 package de.embl.cba.mobie;
 
+import bdv.util.volatiles.SharedQueue;
 import bdv.viewer.SourceAndConverter;
 import de.embl.cba.bdv.utils.BdvUtils;
 import de.embl.cba.bdv.utils.Logger;
@@ -57,7 +58,8 @@ public class MoBIE
 {
 	public static final int N_THREADS = 8;
 	public static final String PROTOTYPE_DISPLAY_VALUE = "01234567890123456789";
-
+	public static final ExecutorService executorService = Executors.newFixedThreadPool( N_THREADS );
+	public static final SharedQueue sharedQueue = new SharedQueue(Math.max(1, Runtime.getRuntime().availableProcessors()));
 	private final String projectName;
 	private MoBIESettings settings;
 	private String datasetName;
@@ -69,6 +71,7 @@ public class MoBIE
 	private String imageRoot;
 	private String tableRoot;
 	private HashMap< String, ImgLoader > sourceNameToImgLoader;
+	private SourceAndConverterService sacService;
 	//private HashMap< String, SourceAndConverter< ? > > sourceNameToSourceAndConverter;
 
 	public MoBIE( String projectRoot ) throws IOException
@@ -85,6 +88,7 @@ public class MoBIE
 		PlaygroundPrefs.setSourceAndConverterUIVisibility( false );
 		project = new ProjectJsonParser().parseProject( FileAndUrlUtils.combinePath( projectRoot,  "project.json" ) );
 		this.settings = setImageDataFormat( projectLocation );
+		sacService = ( SourceAndConverterService ) SourceAndConverterServices.getSourceAndConverterService();
 		openDataset();
 	}
 
@@ -187,8 +191,8 @@ public class MoBIE
 	{
 		List< SourceAndConverter< ? > > sourceAndConverters = new CopyOnWriteArrayList<>();
 		final long start = System.currentTimeMillis();
-		final int nThreads = N_THREADS;
-		final ExecutorService executorService = Executors.newFixedThreadPool( nThreads );
+
+		final ExecutorService executorService = Executors.newFixedThreadPool( N_THREADS );
 		for ( String sourceName : sources )
 		{
 			executorService.execute( () -> {
@@ -196,13 +200,9 @@ public class MoBIE
 			} );
 		}
 
-		executorService.shutdown();
-		try {
-			executorService.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
-		} catch (InterruptedException e) {
-		}
+		Utils.waitUntilFinishedAndShutDown( executorService );
 
-		System.out.println( "Fetched " + sourceAndConverters.size() + " image source(s) in " + (System.currentTimeMillis() - start) + " ms, using " + nThreads + " thread(s).");
+		System.out.println( "Fetched " + sourceAndConverters.size() + " image source(s) in " + (System.currentTimeMillis() - start) + " ms, using " + N_THREADS + " thread(s).");
 
 		return sourceAndConverters;
 	}
@@ -296,8 +296,6 @@ public class MoBIE
 
 	public SourceAndConverter getSourceAndConverter( String sourceName )
 	{
-		final SourceAndConverterService sacService = ( SourceAndConverterService ) SourceAndConverterServices.getSourceAndConverterService();
-
 		final List< SourceAndConverter > sourceAndConverters = sacService.getSourceAndConverters().stream().filter( sac -> sac.getSpimSource().getName().equals( sourceName ) ).collect( Collectors.toList() );
 
 		if ( sourceAndConverters.size() == 1 )
@@ -308,7 +306,8 @@ public class MoBIE
 
 		final ImageSource source = getSource( sourceName );
 		final String imagePath = getImagePath( source );
-        new Thread( () -> IJ.log( "Opening image:\n" + imagePath ) ).start();
+        //new Thread( () -> IJ.log( "Opening image:\n" + imagePath ) ).start();
+		IJ.log( "Opening image:\n" + imagePath );
         final ImageDataFormat imageDataFormat = settings.values.getImageDataFormat();
         SpimData spimData = null;
         switch ( imageDataFormat ) {
@@ -433,11 +432,7 @@ public class MoBIE
 			} );
 		}
 
-		executorService.shutdown();
-		try {
-			executorService.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
-		} catch (InterruptedException e) {
-		}
+		Utils.waitUntilFinishedAndShutDown( executorService );
 
 		System.out.println( "Fetched " + sources.size() + " table(s) in " + (System.currentTimeMillis() - start) + " ms, using " + N_THREADS + " thread(s).");
 

--- a/src/main/java/de/embl/cba/mobie/Utils.java
+++ b/src/main/java/de/embl/cba/mobie/Utils.java
@@ -21,6 +21,8 @@ import java.io.*;
 import java.net.URI;
 import java.util.*;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static de.embl.cba.bdv.utils.BdvUtils.getBdvWindowCenter;
@@ -30,6 +32,15 @@ import static de.embl.cba.tables.imagesegment.SegmentUtils.BB_MIN_Z;
 
 public abstract class Utils
 {
+	public static void waitUntilFinishedAndShutDown( ExecutorService executorService )
+	{
+		executorService.shutdown();
+		try {
+			executorService.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
+		} catch (InterruptedException e) {
+		}
+	}
+
 	public enum FileLocation {
 		Project,
 		FileSystem

--- a/src/main/java/de/embl/cba/mobie/n5/zarr/N5OMEZarrImageLoader.java
+++ b/src/main/java/de/embl/cba/mobie/n5/zarr/N5OMEZarrImageLoader.java
@@ -36,6 +36,7 @@ import bdv.img.cache.SimpleCacheArrayLoader;
 import bdv.img.cache.VolatileGlobalCellCache;
 import bdv.util.ConstantRandomAccessible;
 import bdv.util.MipmapTransforms;
+import bdv.util.volatiles.SharedQueue;
 import com.amazonaws.SdkClientException;
 import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
 import mpicbg.spim.data.generic.sequence.BasicViewSetup;
@@ -99,6 +100,7 @@ public class N5OMEZarrImageLoader implements ViewerImgLoader, MultiResolutionImg
 	private final Map<Integer, Integer> setupToChannel = new HashMap<>();
 	private int sequenceTimepoints = 0;
 	private HashMap<String, Integer> axesMap = new HashMap<>();
+	private BlockingFetchQueues< Callable< ? > > queue;
 
 
 	/**
@@ -119,6 +121,12 @@ public class N5OMEZarrImageLoader implements ViewerImgLoader, MultiResolutionImg
 		fetchSequenceDescriptionAndViewRegistrations();
 	}
 
+	public N5OMEZarrImageLoader(N5Reader n5Reader, HashMap<String, Integer> axesMap, BlockingFetchQueues< Callable< ? > > queue ) {
+		this.n5 = n5Reader;
+		this.axesMap = axesMap;
+		this.queue = queue;
+		fetchSequenceDescriptionAndViewRegistrations();
+	}
 
 	private void fetchSequenceDescriptionAndViewRegistrations() {
 		try {
@@ -291,10 +299,13 @@ public class N5OMEZarrImageLoader implements ViewerImgLoader, MultiResolutionImg
 						maxNumLevels = Math.max(maxNumLevels, setupImgLoader.numMipmapLevels());
 					}
 
-					final int numFetcherThreads = Math.max(1, Runtime.getRuntime().availableProcessors());
-					final BlockingFetchQueues<Callable<?>> queue = new BlockingFetchQueues<>(maxNumLevels, numFetcherThreads);
-					fetchers = new FetcherThreads(queue, numFetcherThreads);
-					cache = new VolatileGlobalCellCache(queue);
+					if ( queue == null )
+					{
+						final int numFetcherThreads = Math.max( 1, Runtime.getRuntime().availableProcessors() );
+						queue = new BlockingFetchQueues<>( maxNumLevels, numFetcherThreads );
+						fetchers = new FetcherThreads( queue, numFetcherThreads);
+					}
+					cache = new VolatileGlobalCellCache( queue );
 				} catch (IOException e) {
 					throw new RuntimeException(e);
 				}
@@ -389,7 +400,8 @@ public class N5OMEZarrImageLoader implements ViewerImgLoader, MultiResolutionImg
 			synchronized (this) {
 				if (!isOpen)
 					return;
-				fetchers.shutdown();
+				if ( fetchers != null )
+					fetchers.shutdown();
 				cache.clearCache();
 				isOpen = false;
 			}

--- a/src/main/java/de/embl/cba/mobie/n5/zarr/OMEZarrReader.java
+++ b/src/main/java/de/embl/cba/mobie/n5/zarr/OMEZarrReader.java
@@ -1,6 +1,7 @@
 package de.embl.cba.mobie.n5.zarr;
 
 import com.google.gson.GsonBuilder;
+import de.embl.cba.mobie.MoBIE;
 import ij.IJ;
 import mpicbg.spim.data.SpimData;
 import net.imglib2.util.Cast;
@@ -14,6 +15,7 @@ public class OMEZarrReader
     private static boolean logChunkLoading;
 
     private final String filePath;
+    ;
 
     public OMEZarrReader(String filePath)
     {
@@ -38,7 +40,7 @@ public class OMEZarrReader
         N5OMEZarrImageLoader.logChunkLoading = logChunkLoading;
         N5OmeZarrReader reader = new N5OmeZarrReader(this.filePath, new GsonBuilder());
         HashMap<String, Integer> axesMap = reader.getAxes();
-        N5OMEZarrImageLoader imageLoader = new N5OMEZarrImageLoader(reader, axesMap);
+        N5OMEZarrImageLoader imageLoader = new N5OMEZarrImageLoader(reader, axesMap, MoBIE.sharedQueue);
         return new SpimData(
                 new File(this.filePath),
                 Cast.unchecked( imageLoader.getSequenceDescription() ),

--- a/src/main/java/de/embl/cba/mobie/transform/GridSourceTransformer.java
+++ b/src/main/java/de/embl/cba/mobie/transform/GridSourceTransformer.java
@@ -3,7 +3,6 @@ package de.embl.cba.mobie.transform;
 import bdv.viewer.SourceAndConverter;
 import de.embl.cba.mobie.MoBIE;
 import de.embl.cba.mobie.Utils;
-import net.imglib2.FinalRealInterval;
 import net.imglib2.RealInterval;
 import net.imglib2.realtransform.AffineTransform3D;
 import net.imglib2.type.numeric.NumericType;
@@ -15,7 +14,6 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 public class GridSourceTransformer< T extends NumericType< T > > extends AbstractSourceTransformer< T >
@@ -56,8 +54,10 @@ public class GridSourceTransformer< T extends NumericType< T > > extends Abstrac
 	private void transformSources( List< SourceAndConverter< T > > inputSources, List< SourceAndConverter< T > > transformedSources, double spacingX, double spacingY )
 	{
 		final long start = System.currentTimeMillis();
+
 		final int nThreads = MoBIE.N_THREADS;
 		final ExecutorService executorService = Executors.newFixedThreadPool( nThreads );
+		//final ExecutorService executorService = MoBIE.executorService;
 
 		for ( String gridId : sources.keySet() )
 		{
@@ -66,11 +66,7 @@ public class GridSourceTransformer< T extends NumericType< T > > extends Abstrac
 			} );
 		}
 
-		executorService.shutdown();
-		try {
-			executorService.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
-		} catch (InterruptedException e) {
-		}
+		Utils.waitUntilFinishedAndShutDown( executorService );
 
 		System.out.println( "Transformed " + inputSources.size() + " image source(s) in " + (System.currentTimeMillis() - start) + " ms, using " + nThreads + " thread(s)." );
 	}

--- a/src/main/java/de/embl/cba/mobie/view/ViewManager.java
+++ b/src/main/java/de/embl/cba/mobie/view/ViewManager.java
@@ -234,7 +234,7 @@ public class ViewManager
 		}
 	}
 
-	private void showSourceDisplay( SourceDisplay sourceDisplay )
+	private synchronized void showSourceDisplay( SourceDisplay sourceDisplay )
 	{
 		if ( currentSourceDisplays.contains( sourceDisplay ) ) return;
 


### PR DESCRIPTION
Hi @KateMoreva (cc @K-Meech),

I hacked in a `SharedQueue` for OMEZarr. This helps in terms of not creating too many threads when adding very many Sources to BDV.

I would like to merge this as it will enable @constantinpape to have a look at the plate view images.
But it would be good if you could take note of what I did here such that we can make a nice implementation of this in bdv-imageloader.