### PR TITLE
add default constructor

### DIFF
--- a/src/main/java/de/embl/cba/mobie/display/AnnotatedIntervalDisplay.java
+++ b/src/main/java/de/embl/cba/mobie/display/AnnotatedIntervalDisplay.java
@@ -36,7 +36,7 @@ public class AnnotatedIntervalDisplay extends AnnotatedRegionDisplay< AnnotatedI
 		return sources;
 	}
 
-
+	public AnnotatedIntervalDisplay() {}
 
 	public AnnotatedIntervalDisplay( String name, double opacity, Map< String, List< String > > sources, String lut, String colorByColumn, Double[] valueLimits, List< String > selectedSegmentIds, boolean showScatterPlot, String[] scatterPlotAxes, List< String > tables )
 	{

--- a/src/main/java/de/embl/cba/mobie/display/ImageSourceDisplay.java
+++ b/src/main/java/de/embl/cba/mobie/display/ImageSourceDisplay.java
@@ -44,6 +44,8 @@ public class ImageSourceDisplay extends SourceDisplay
 		return sources;
 	}
 
+	public ImageSourceDisplay() {}
+
 	// Constructor for serialization
 	public ImageSourceDisplay( String name, double opacity, List< String > sources, String color, double[] contrastLimits, BlendingMode blendingMode, boolean showImagesIn3d ) {
 		this.name = name;

--- a/src/main/java/de/embl/cba/mobie/display/SegmentationSourceDisplay.java
+++ b/src/main/java/de/embl/cba/mobie/display/SegmentationSourceDisplay.java
@@ -51,6 +51,8 @@ public class SegmentationSourceDisplay extends AnnotatedRegionDisplay< TableRowI
 		return showSelectedSegmentsIn3d;
 	}
 
+	public SegmentationSourceDisplay(){}
+
 	public SegmentationSourceDisplay( String name, double opacity, List< String > sources,
 									  String lut, String colorByColumn, Double[] valueLimits,
 									  List< String > selectedSegmentIds, boolean showSelectedSegmentsIn3d,


### PR DESCRIPTION
Fixes https://github.com/mobie/mobie-viewer-fiji/issues/397

@tischi Ok! So it turns out, that if you don't have a default/empty constructor then gson.fromJson() sets any missing fields to their default values. i.e. null for objects, false for booleans etc.. It won't use the values you state as field=value.

I fixed this for the displays, but if there's anywhere else you rely on default values, you will need to add a constructor! 