### PR TITLE
fix javadoc errors

### DIFF
--- a/src/main/java/de/embl/cba/mobie/bdv/render/AccumulateOccludingProjectorARGBFactory.java
+++ b/src/main/java/de/embl/cba/mobie/bdv/render/AccumulateOccludingProjectorARGBFactory.java
@@ -38,7 +38,7 @@ import net.imglib2.type.numeric.ARGBType;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 
-/**
+/*
  * For information about this projector, see {@link AccumulateMixedProjectorARGB}
  */
 

--- a/src/main/java/de/embl/cba/mobie/bdv/render/AccumulateOccludingProjectorARGBFactoryAdapter.java
+++ b/src/main/java/de/embl/cba/mobie/bdv/render/AccumulateOccludingProjectorARGBFactoryAdapter.java
@@ -4,7 +4,7 @@ import bdv.viewer.render.AccumulateProjectorFactory;
 import org.scijava.plugin.Plugin;
 import sc.fiji.persist.IClassRuntimeAdapter;
 
-/**
+/*
  * For serialization of {@link AccumulateOccludingProjectorARGBFactoryAdapter} objects
  *
  * Used in {@link sc.fiji.bdvpg.bdv.supplier.mobie.MobieSerializableBdvOptions}

--- a/src/main/java/de/embl/cba/mobie/bdv/render/BlendingMode.java
+++ b/src/main/java/de/embl/cba/mobie/bdv/render/BlendingMode.java
@@ -2,7 +2,7 @@ package de.embl.cba.mobie.bdv.render;
 
 import com.google.gson.annotations.SerializedName;
 
-/**
+/*
  * Constants to define the blending mode of sources.
  * These constants are used within {@link AccumulateMixedProjectorARGB}.
  *


### PR DESCRIPTION
Turns javadoc comments with errors into normal multi-line comments.