### PR TITLE
remove extra wrap

### DIFF
--- a/src/main/java/org/embl/mobie/viewer/MoBIE.java
+++ b/src/main/java/org/embl/mobie/viewer/MoBIE.java
@@ -302,8 +302,6 @@ public class MoBIE
         final SourceAndConverterFromSpimDataCreator creator = new SourceAndConverterFromSpimDataCreator( spimData );
         SourceAndConverter<?> sourceAndConverter = creator.getSetupIdToSourceAndConverter().values().iterator().next();
 
-        // wrap as TransformedSource
-        sourceAndConverter = new SourceAffineTransformer( sourceAndConverter, new AffineTransform3D( ) ).getSourceOut();
         return sourceAndConverter;
     }
 


### PR DESCRIPTION
Closes https://github.com/mobie/mobie-viewer-fiji/issues/465
@tischi I removed the extra wrapping as a transformed source. I checked that we could still manually move sources and save/load a view. All worked fine :)