### PR TITLE
Project creator laf

### DIFF
--- a/src/main/java/org/embl/mobie/viewer/annotate/Annotator.java
+++ b/src/main/java/org/embl/mobie/viewer/annotate/Annotator.java
@@ -37,6 +37,7 @@ import de.embl.cba.tables.tablerow.TableRow;
 import de.embl.cba.tables.tablerow.TableRowImageSegment;
 import ij.IJ;
 import net.imglib2.type.numeric.ARGBType;
+import org.embl.mobie.viewer.ui.MoBIELookAndFeelToggler;
 
 import javax.swing.*;
 import javax.swing.table.TableModel;
@@ -45,9 +46,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
-import static org.embl.mobie.viewer.ui.UserInterfaceHelper.resetSystemSwingLookAndFeel;
-import static org.embl.mobie.viewer.ui.UserInterfaceHelper.setMoBIESwingLookAndFeel;
 
 public class Annotator< T extends TableRow > extends JFrame
 {
@@ -85,10 +83,10 @@ public class Annotator< T extends TableRow > extends JFrame
 
 	public void showDialog()
 	{
-		setMoBIESwingLookAndFeel();
+		MoBIELookAndFeelToggler.setMoBIELaf();
 		createDialog();
 		showFrame();
-		resetSystemSwingLookAndFeel();
+		MoBIELookAndFeelToggler.resetMoBIELaf();
 	}
 
 	private void createDialog()
@@ -165,7 +163,7 @@ public class Annotator< T extends TableRow > extends JFrame
 
 	private void addAnnotationButtonPanel( String annotationName, T tableRow )
 	{
-		setMoBIESwingLookAndFeel();
+		MoBIELookAndFeelToggler.setMoBIELaf();
 		annotationNames.add( annotationName );
 		final JPanel panel = SwingUtils.horizontalLayoutPanel();
 
@@ -216,7 +214,7 @@ public class Annotator< T extends TableRow > extends JFrame
 		panel.add( changeColor );
 		annotationButtonsContainer.add( panel );
 		refreshDialog();
-		resetSystemSwingLookAndFeel();
+		MoBIELookAndFeelToggler.resetMoBIELaf();
 	}
 
 	private void addTableRowBrowserSelectPreviousAndNextPanel( )

--- a/src/main/java/org/embl/mobie/viewer/projectcreator/ui/ProjectsCreatorPanel.java
+++ b/src/main/java/org/embl/mobie/viewer/projectcreator/ui/ProjectsCreatorPanel.java
@@ -36,7 +36,7 @@ public class ProjectsCreatorPanel extends JFrame {
 
     public ProjectsCreatorPanel ( File projectLocation ) throws IOException {
 
-        UserInterfaceHelper.setMoBIESwingLookAndFeel();
+        UserInterfaceHelper.resetSystemSwingLookAndFeel();
         // account for projects with and without the top 'data' directory
         File dataDirectory = ProjectCreatorHelper.getDataLocation( projectLocation );
         this.projectsCreator = new ProjectCreator( dataDirectory );
@@ -55,15 +55,13 @@ public class ProjectsCreatorPanel extends JFrame {
         this.setTitle( "Editing MoBIE Project: " + shortenedProjectName );
         this.getContentPane().setLayout( new BoxLayout(this.getContentPane(), BoxLayout.Y_AXIS ) );
         this.setDefaultCloseOperation( JFrame.DISPOSE_ON_CLOSE );
-        UserInterfaceHelper.resetSystemSwingLookAndFeel();
     }
 
     public void showProjectsCreatorPanel() {
-        UserInterfaceHelper.setMoBIESwingLookAndFeel();
+        UserInterfaceHelper.resetSystemSwingLookAndFeel();
         this.pack();
         this.setLocationRelativeTo(null);
         this.setVisible( true );
-        UserInterfaceHelper.resetSystemSwingLookAndFeel();
     }
 
     public ProjectCreator getProjectsCreator() {

--- a/src/main/java/org/embl/mobie/viewer/projectcreator/ui/ProjectsCreatorPanel.java
+++ b/src/main/java/org/embl/mobie/viewer/projectcreator/ui/ProjectsCreatorPanel.java
@@ -36,7 +36,6 @@ public class ProjectsCreatorPanel extends JFrame {
 
     public ProjectsCreatorPanel ( File projectLocation ) throws IOException {
 
-        UserInterfaceHelper.resetSystemSwingLookAndFeel();
         // account for projects with and without the top 'data' directory
         File dataDirectory = ProjectCreatorHelper.getDataLocation( projectLocation );
         this.projectsCreator = new ProjectCreator( dataDirectory );
@@ -58,7 +57,6 @@ public class ProjectsCreatorPanel extends JFrame {
     }
 
     public void showProjectsCreatorPanel() {
-        UserInterfaceHelper.resetSystemSwingLookAndFeel();
         this.pack();
         this.setLocationRelativeTo(null);
         this.setVisible( true );

--- a/src/main/java/org/embl/mobie/viewer/ui/MoBIELookAndFeelToggler.java
+++ b/src/main/java/org/embl/mobie/viewer/ui/MoBIELookAndFeelToggler.java
@@ -8,11 +8,12 @@ public class MoBIELookAndFeelToggler {
 
     private static LookAndFeel before;
 
-    public static void storeCurrentLaf() {
+    private static void storeCurrentLaf() {
         before = UIManager.getLookAndFeel();
     }
 
     public static void setMoBIELaf() {
+        storeCurrentLaf();
         FlatLightLaf.install();
         System.setProperty("apple.laf.useScreenMenuBar", "false");
         try {

--- a/src/main/java/org/embl/mobie/viewer/ui/MoBIELookAndFeelToggler.java
+++ b/src/main/java/org/embl/mobie/viewer/ui/MoBIELookAndFeelToggler.java
@@ -1,0 +1,33 @@
+package org.embl.mobie.viewer.ui;
+
+import com.formdev.flatlaf.FlatLightLaf;
+
+import javax.swing.*;
+
+public class MoBIELookAndFeelToggler {
+
+    private static LookAndFeel before;
+
+    public static void storeCurrentLaf() {
+        before = UIManager.getLookAndFeel();
+    }
+
+    public static void setMoBIELaf() {
+        FlatLightLaf.install();
+        System.setProperty("apple.laf.useScreenMenuBar", "false");
+        try {
+            UIManager.setLookAndFeel( new FlatLightLaf() );
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void resetMoBIELaf() {
+        // TODO: reset where the menu bar is?
+        try {
+            UIManager.setLookAndFeel( before );
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/org/embl/mobie/viewer/ui/UserInterface.java
+++ b/src/main/java/org/embl/mobie/viewer/ui/UserInterface.java
@@ -26,7 +26,8 @@ public class UserInterface
 
 	public UserInterface( MoBIE moBIE )
 	{
-		setMoBIESwingLookAndFeel();
+		MoBIELookAndFeelToggler.storeCurrentLaf();
+		MoBIELookAndFeelToggler.setMoBIELaf();
 		userInterfaceHelper = new UserInterfaceHelper( moBIE );
 
 		selectionContainer = userInterfaceHelper.createSelectionPanel();
@@ -34,7 +35,7 @@ public class UserInterface
 		displayToPanel = new HashMap<>();
 
 		frame = createAndShowFrame( selectionContainer, displaySettingsContainer, moBIE.getProjectName() + "-" + moBIE.getDatasetName() );
-		resetSystemSwingLookAndFeel();
+		MoBIELookAndFeelToggler.resetMoBIELaf();
 	}
 
 	private JFrame createAndShowFrame( JPanel actionPanel, JPanel displaySettingsPanel, String panelName )

--- a/src/main/java/org/embl/mobie/viewer/ui/UserInterface.java
+++ b/src/main/java/org/embl/mobie/viewer/ui/UserInterface.java
@@ -26,7 +26,6 @@ public class UserInterface
 
 	public UserInterface( MoBIE moBIE )
 	{
-		MoBIELookAndFeelToggler.storeCurrentLaf();
 		MoBIELookAndFeelToggler.setMoBIELaf();
 		userInterfaceHelper = new UserInterfaceHelper( moBIE );
 

--- a/src/main/java/org/embl/mobie/viewer/ui/UserInterfaceHelper.java
+++ b/src/main/java/org/embl/mobie/viewer/ui/UserInterfaceHelper.java
@@ -176,34 +176,6 @@ public class UserInterfaceHelper
 
 	}
 
-	public static void setMoBIESwingLookAndFeel() {
-		FlatLightLaf.install();
-		System.setProperty("apple.laf.useScreenMenuBar", "false");
-		try {
-			UIManager.setLookAndFeel( new FlatLightLaf() );
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
-	}
-
-	public static void resetSystemSwingLookAndFeel() {
-		// TODO: reset where the menu bar is?
-		try {
-			UIManager.setLookAndFeel( UIManager.getSystemLookAndFeelClassName() );
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
-	}
-
-	public static void resetCrossPlatformSwingLookAndFeel() {
-		// TODO: reset where the menu bar is?
-		try {
-			UIManager.setLookAndFeel( UIManager.getCrossPlatformLookAndFeelClassName() );
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
-	}
-
 	public JPanel createAnnotatedIntervalDisplaySettingsPanel( AnnotatedIntervalDisplay display )
 	{
 		JPanel panel = createDisplayPanel( display.getName() );

--- a/src/main/java/org/embl/mobie/viewer/view/ViewManager.java
+++ b/src/main/java/org/embl/mobie/viewer/view/ViewManager.java
@@ -26,6 +26,7 @@ import org.embl.mobie.viewer.source.SegmentationSource;
 import org.embl.mobie.viewer.table.TableDataFormat;
 import org.embl.mobie.viewer.table.TableViewer;
 import org.embl.mobie.viewer.transform.AffineSourceTransformer;
+import org.embl.mobie.viewer.ui.MoBIELookAndFeelToggler;
 import org.embl.mobie.viewer.ui.UserInterface;
 import org.embl.mobie.viewer.ui.WindowArrangementHelper;
 import org.embl.mobie.viewer.view.additionalviews.AdditionalViewsLoader;
@@ -259,11 +260,11 @@ public class ViewManager
 		moBIE.addSourceAndConverters( sourceNameToSourceAndConverters );
 
 		// show the displays
-		setMoBIESwingLookAndFeel();
+		MoBIELookAndFeelToggler.setMoBIELaf();
 		final List< SourceDisplay > sourceDisplays = view.getSourceDisplays();
 		for ( SourceDisplay sourceDisplay : sourceDisplays )
 			showSourceDisplay( sourceDisplay );
-		resetSystemSwingLookAndFeel();
+		MoBIELookAndFeelToggler.resetMoBIELaf();
 
 		// adjust viewer transform
 		adjustViewerTransform( view );

--- a/src/main/java/org/embl/mobie/viewer/view/additionalviews/AdditionalViewsLoader.java
+++ b/src/main/java/org/embl/mobie/viewer/view/additionalviews/AdditionalViewsLoader.java
@@ -5,6 +5,7 @@ import org.embl.mobie.viewer.MoBIESettings;
 import org.embl.mobie.viewer.MoBIE;
 import org.embl.mobie.viewer.Utils;
 import org.embl.mobie.viewer.serialize.AdditionalViewsJsonParser;
+import org.embl.mobie.viewer.ui.MoBIELookAndFeelToggler;
 import org.embl.mobie.viewer.ui.UserInterfaceHelper;
 import org.embl.mobie.viewer.view.View;
 
@@ -33,7 +34,7 @@ public class AdditionalViewsLoader {
             }
 
             // to match to the existing view selection panels, we enable the mobie look and feel
-            UserInterfaceHelper.setMoBIESwingLookAndFeel();
+            MoBIELookAndFeelToggler.setMoBIELaf();
 
             if (selectedFilePath != null) {
                 Map< String, View> views = new AdditionalViewsJsonParser().getViews( selectedFilePath ).views;
@@ -41,7 +42,7 @@ public class AdditionalViewsLoader {
                 IJ.log( "New views loaded from: " + selectedFilePath );
             }
 
-            UserInterfaceHelper.resetSystemSwingLookAndFeel();
+            MoBIELookAndFeelToggler.resetMoBIELaf();
 
         } catch (IOException e) {
             e.printStackTrace();

--- a/src/main/java/org/embl/mobie/viewer/view/saving/SelectExistingViewFrame.java
+++ b/src/main/java/org/embl/mobie/viewer/view/saving/SelectExistingViewFrame.java
@@ -2,13 +2,13 @@ package org.embl.mobie.viewer.view.saving;
 
 import org.embl.mobie.viewer.Dataset;
 import org.embl.mobie.viewer.MoBIE;
+import org.embl.mobie.viewer.ui.MoBIELookAndFeelToggler;
 import org.embl.mobie.viewer.view.View;
 import org.embl.mobie.viewer.view.additionalviews.AdditionalViews;
 import de.embl.cba.tables.SwingUtils;
 import ij.IJ;
 import org.embl.mobie.viewer.projectcreator.ProjectCreatorHelper;
 import org.embl.mobie.viewer.ui.SwingHelper;
-import org.embl.mobie.viewer.ui.UserInterfaceHelper;
 
 import javax.swing.*;
 import java.awt.*;
@@ -40,7 +40,7 @@ public class SelectExistingViewFrame extends JFrame {
 
     // writing to dataset json
     public SelectExistingViewFrame( Dataset dataset, View view, String jsonPath ) {
-        UserInterfaceHelper.setMoBIESwingLookAndFeel();
+        MoBIELookAndFeelToggler.setMoBIELaf();
         this.dataset = dataset;
         this.view = view;
         this.jsonPath = jsonPath;
@@ -50,7 +50,7 @@ public class SelectExistingViewFrame extends JFrame {
 
     // write to additional views json
     public SelectExistingViewFrame( AdditionalViews additionalViews, View view, String jsonPath ) {
-        UserInterfaceHelper.setMoBIESwingLookAndFeel();
+        MoBIELookAndFeelToggler.setMoBIELaf();
         this.additionalViews = additionalViews;
         this.view = view;
         this.jsonPath = jsonPath;
@@ -70,7 +70,7 @@ public class SelectExistingViewFrame extends JFrame {
             @Override
             public void windowClosing(WindowEvent e)
             {
-                UserInterfaceHelper.resetSystemSwingLookAndFeel();
+                MoBIELookAndFeelToggler.resetMoBIELaf();
                 e.getWindow().dispose();
             }
         });


### PR DESCRIPTION
For https://github.com/mobie/mobie-viewer-fiji/issues/468

- stores the laf when mobie is opened, and resets to this
- sets no laf for the project creator, so the default is used

This means menus/dialogs before and after using mobie now look the same on Windows (and hopefully on all other os!)
Project creator on windows:
![Screenshot (354)](https://user-images.githubusercontent.com/24316371/135242445-f6a26aff-27ef-45af-b93a-a9c84d6ffc37.png)

@tischi - does this look alright on mac too?