### PR TITLE
Replace views of the same name

### DIFF
--- a/src/main/java/org/embl/mobie/viewer/ui/UserInterfaceHelper.java
+++ b/src/main/java/org/embl/mobie/viewer/ui/UserInterfaceHelper.java
@@ -9,7 +9,6 @@ import com.formdev.flatlaf.FlatLightLaf;
 import com.google.gson.Gson;
 import de.embl.cba.bdv.utils.BdvUtils;
 import de.embl.cba.bdv.utils.BrightnessUpdateListener;
-import kotlin.random.Random;
 import org.embl.mobie.viewer.*;
 import org.embl.mobie.viewer.display.AbstractSourceDisplay;
 import org.embl.mobie.viewer.display.AnnotatedIntervalDisplay;

--- a/src/main/java/org/embl/mobie/viewer/ui/UserInterfaceHelper.java
+++ b/src/main/java/org/embl/mobie/viewer/ui/UserInterfaceHelper.java
@@ -9,6 +9,7 @@ import com.formdev.flatlaf.FlatLightLaf;
 import com.google.gson.Gson;
 import de.embl.cba.bdv.utils.BdvUtils;
 import de.embl.cba.bdv.utils.BrightnessUpdateListener;
+import kotlin.random.Random;
 import org.embl.mobie.viewer.*;
 import org.embl.mobie.viewer.display.AbstractSourceDisplay;
 import org.embl.mobie.viewer.display.AnnotatedIntervalDisplay;
@@ -378,7 +379,12 @@ public class UserInterfaceHelper
 			for ( String viewName : views.keySet() ) {
 				String uiSelectionGroup = views.get( viewName ).getUiSelectionGroup();
 				if ( groupingsToComboBox.containsKey( uiSelectionGroup ) ) {
-					groupingsToComboBox.get( uiSelectionGroup ).addItem( viewName );
+					JComboBox comboBox = groupingsToComboBox.get( uiSelectionGroup );
+					// check if a view of that name already exists: -1 means it doesn't exist
+					int index = ( (DefaultComboBoxModel) comboBox.getModel() ).getIndexOf( viewName );
+					if ( index == -1 ) {
+						comboBox.addItem(viewName);
+					}
 				} else {
 					final JPanel selectionPanel = createViewSelectionPanel(moBIE, uiSelectionGroup, groupingsToViews.get(uiSelectionGroup));
 					int alphabeticalIndex = uiSelectionGroups.indexOf( uiSelectionGroup );


### PR DESCRIPTION
Closes https://github.com/mobie/mobie-viewer-fiji/issues/470

- checks if a view is already present in a particular group dropdown. This stops 'loading additional views..' with views of the same name leading to multiple entries in the dropdown. Newly loaded views replace old ones.