### PR TITLE
remove sourceTransformers that apply to non-displayed sources

### DIFF
--- a/src/main/java/org/embl/mobie/viewer/Utils.java
+++ b/src/main/java/org/embl/mobie/viewer/Utils.java
@@ -391,4 +391,13 @@ public abstract class Utils
 			values.set( i, String.valueOf( Double.parseDouble( values.get( i ) ) ) );
 		}
 	}
+
+	public static boolean containsAtLeastOne( Collection<String> a, Collection<String> b ) {
+		for ( String item : b ) {
+			if ( a.contains( item ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
 }

--- a/src/main/java/org/embl/mobie/viewer/view/ViewManager.java
+++ b/src/main/java/org/embl/mobie/viewer/view/ViewManager.java
@@ -53,6 +53,7 @@ import java.util.*;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.embl.mobie.viewer.Utils.containsAtLeastOne;
 import static org.embl.mobie.viewer.ui.UserInterfaceHelper.*;
 
 public class ViewManager
@@ -501,6 +502,22 @@ public class ViewManager
 
 		userInterface.removeDisplaySettingsPanel( sourceDisplay );
 		currentSourceDisplays.remove( sourceDisplay );
+
+		// remove any sourceTransformers, where none of its relevant 'sources' are displayed
+
+		// create a copy of the currently shown source transformers, so we don't iterate over a list that we modify
+		final ArrayList< SourceTransformer > sourceTransformersCopy = new ArrayList<>( this.currentSourceTransformers ) ;
+
+		Set<String> currentlyDisplayedSources = new HashSet<>();
+		for ( SourceDisplay display: currentSourceDisplays ) {
+			currentlyDisplayedSources.addAll( display.getSources() );
+		}
+
+		for ( SourceTransformer sourceTransformer: sourceTransformersCopy ) {
+			if ( !containsAtLeastOne( currentlyDisplayedSources, sourceTransformer.getSources() )) {
+				currentSourceTransformers.remove( sourceTransformer );
+			}
+		}
 	}
 
 	public Collection< SegmentationSourceDisplay > getSegmentationDisplays()


### PR DESCRIPTION
For https://github.com/mobie/mobie-viewer-fiji/issues/471

When a sourceDisplay is removed, it also removes any sourceTransformers that no longer apply to any displayed sources. (prevents old sourceTransformers being saved into views)


