### PR TITLE
Overwrite images

### DIFF
--- a/src/main/java/org/embl/mobie/viewer/command/WriteOMEZARRCommand.java
+++ b/src/main/java/org/embl/mobie/viewer/command/WriteOMEZARRCommand.java
@@ -6,6 +6,7 @@ import org.embl.mobie.io.ome.zarr.writers.imgplus.WriteImgPlusToN5OmeZarr;
 import org.embl.mobie.viewer.projectcreator.ui.ManualExportPanel;
 import ij.ImagePlus;
 import net.imglib2.realtransform.AffineTransform3D;
+import org.janelia.saalfeldlab.n5.Compression;
 import org.janelia.saalfeldlab.n5.GzipCompression;
 import org.scijava.command.Command;
 import org.scijava.plugin.Parameter;
@@ -55,7 +56,15 @@ public class WriteOMEZARRCommand implements Command {
                 new WriteImgPlusToN5OmeZarr().export(currentImage, filePath, sourceTransform, method,
                         new GzipCompression(), new String[]{imageName});
             } else {
-                new ManualExportPanel( currentImage, filePath, sourceTransform, method, imageName, ImageDataFormat.OmeZarr ).getManualExportParameters();
+                ManualExportPanel manualExportPanel = new ManualExportPanel( ImageDataFormat.OmeZarr );
+                int[][] resolutions = manualExportPanel.getResolutions();
+                int[][] subdivisions = manualExportPanel.getSubdivisions();
+                Compression compression = manualExportPanel.getCompression();
+
+                if ( resolutions != null && subdivisions != null && compression != null ) {
+                    new WriteImgPlusToN5OmeZarr().export(currentImage, resolutions, subdivisions, filePath, sourceTransform,
+                            method, compression, new String[]{imageName});
+                }
             }
         }
     }

--- a/src/main/java/org/embl/mobie/viewer/projectcreator/ImagesCreator.java
+++ b/src/main/java/org/embl/mobie/viewer/projectcreator/ImagesCreator.java
@@ -44,8 +44,10 @@ import sc.fiji.bdvpg.sourceandconverter.importer.SourceAndConverterFromSpimDataC
 import mpicbg.spim.data.sequence.SequenceDescription;
 
 import javax.swing.*;
+import java.awt.*;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -73,13 +75,18 @@ public class ImagesCreator {
     }
 
     private String getDefaultLocalImageXmlPath( String datasetName, String imageName, ImageDataFormat imageDataFormat ) {
-        return FileAndUrlUtils.combinePath(projectCreator.getDataLocation().getAbsolutePath(), datasetName,
-                "images", imageFormatToFolderName( imageDataFormat ), imageName + ".xml");
+        return FileAndUrlUtils.combinePath(getDefaultLocalImageDirPath(datasetName, imageDataFormat),
+                imageName + ".xml");
     }
 
     private String getDefaultLocalImageZarrPath( String datasetName, String imageName, ImageDataFormat imageDataFormat ) {
-        return FileAndUrlUtils.combinePath(projectCreator.getDataLocation().getAbsolutePath(), datasetName,
-                "images", imageFormatToFolderName( imageDataFormat ), imageName + ".ome.zarr");
+        return FileAndUrlUtils.combinePath(getDefaultLocalImageDirPath(datasetName, imageDataFormat),
+                imageName + ".ome.zarr");
+    }
+
+    private String getDefaultLocalN5Path( String datasetName, String imageName ) {
+        return FileAndUrlUtils.combinePath( getDefaultLocalImageDirPath( datasetName, ImageDataFormat.BdvN5),
+                imageName + ".n5" );
     }
 
     private String getDefaultLocalImageDirPath( String datasetName, ImageDataFormat imageDataFormat ) {
@@ -88,7 +95,12 @@ public class ImagesCreator {
     }
 
     private String getDefaultTableDirPath( String datasetName, String imageName ) {
-        return FileAndUrlUtils.combinePath( projectCreator.getDataLocation().getAbsolutePath(), datasetName, "tables", imageName );
+        return FileAndUrlUtils.combinePath( projectCreator.getDataLocation().getAbsolutePath(),
+                datasetName, "tables", imageName );
+    }
+
+    private String getDefaultTablePath( String datasetName, String imageName ) {
+        return FileAndUrlUtils.combinePath( getDefaultTableDirPath(datasetName, imageName), "default.tsv" );
     }
 
     public boolean imageExists( String datasetName, String imageName, ImageDataFormat imageDataFormat ) {
@@ -100,7 +112,7 @@ public class ImagesCreator {
     public void addImage ( ImagePlus imp, String imageName, String datasetName,
                            ImageDataFormat imageDataFormat, ProjectCreator.ImageType imageType,
                            AffineTransform3D sourceTransform, String uiSelectionGroup,
-                           boolean exclusive ) {
+                           boolean exclusive ) throws SpimDataException, IOException {
         addImage( imp, imageName, datasetName, imageDataFormat, imageType, sourceTransform, uiSelectionGroup,
                 exclusive, null, null, null );
 
@@ -109,13 +121,14 @@ public class ImagesCreator {
     public void addImage ( ImagePlus imp, String imageName, String datasetName,
                            ImageDataFormat imageDataFormat, ProjectCreator.ImageType imageType,
                            AffineTransform3D sourceTransform, String uiSelectionGroup, boolean exclusive,
-                           int[][] resolutions, int[][] subdivisions, Compression compression ) {
+                           int[][] resolutions, int[][] subdivisions, Compression compression ) throws IOException, SpimDataException {
         // either xml file path or zarr file path depending on imageDataFormat
         String filePath = getDefaultLocalImagePath( datasetName, imageName, imageDataFormat );
         File imageFile = new File(filePath);
 
         if ( imageFile.exists() ) {
             IJ.log("Overwriting image " + imageName + " in dataset " + datasetName );
+            deleteImageFiles( datasetName, imageName, imageDataFormat );
         }
 
         DownsampleBlock.DownsamplingMethod downsamplingMethod = getDownsamplingMethod( imageType );
@@ -140,20 +153,16 @@ public class ImagesCreator {
             } else {
                 is2D = false;
             }
-            try {
-                if (imageType == ProjectCreator.ImageType.image) {
-                    double[] contrastLimits = new double[]{imp.getDisplayRangeMin(), imp.getDisplayRangeMax()};
-                    LUT lut = imp.getLuts()[0];
-                    String colour = "r=" + lut.getRed(255) + ",g=" + lut.getGreen(255) + ",b=" +
-                            lut.getBlue(255) + ",a=" + lut.getAlpha(255);
-                    updateTableAndJsonsForNewImage(imageName, datasetName, uiSelectionGroup, is2D,
-                            imp.getNFrames(), imageDataFormat, contrastLimits, colour, exclusive );
-                } else {
-                    updateTableAndJsonsForNewSegmentation(imageName, datasetName, uiSelectionGroup, is2D,
-                            imp.getNFrames(), imageDataFormat, exclusive );
-                }
-            } catch (SpimDataException e) {
-                e.printStackTrace();
+            if (imageType == ProjectCreator.ImageType.image) {
+                double[] contrastLimits = new double[]{imp.getDisplayRangeMin(), imp.getDisplayRangeMax()};
+                LUT lut = imp.getLuts()[0];
+                String colour = "r=" + lut.getRed(255) + ",g=" + lut.getGreen(255) + ",b=" +
+                        lut.getBlue(255) + ",a=" + lut.getAlpha(255);
+                updateTableAndJsonsForNewImage(imageName, datasetName, uiSelectionGroup, is2D,
+                        imp.getNFrames(), imageDataFormat, contrastLimits, colour, exclusive );
+            } else {
+                updateTableAndJsonsForNewSegmentation(imageName, datasetName, uiSelectionGroup, is2D,
+                        imp.getNFrames(), imageDataFormat, exclusive );
             }
         }
 
@@ -225,6 +234,48 @@ public class ImagesCreator {
         }
     }
 
+    private void deleteImageFiles( String datasetName, String imageName, ImageDataFormat imageDataFormat ) throws IOException {
+
+        File xmlFile = null;
+        File n5File = null;
+        File zarrFile = null;
+        switch( imageDataFormat ) {
+            case BdvN5:
+                xmlFile = new File( getDefaultLocalImageXmlPath( datasetName, imageName, imageDataFormat ) );
+                n5File = new File( getDefaultLocalN5Path( datasetName, imageName ) );
+                break;
+
+            case BdvOmeZarr:
+                xmlFile = new File( getDefaultLocalImageXmlPath( datasetName, imageName, imageDataFormat ) );
+                zarrFile = new File( getDefaultLocalImageZarrPath( datasetName, imageName, imageDataFormat ) );
+                break;
+
+            case OmeZarr:
+                zarrFile = new File( getDefaultLocalImageZarrPath( datasetName, imageName, imageDataFormat ) );
+                break;
+
+            default:
+                throw new UnsupportedOperationException();
+
+        }
+
+        File tableFile = new File( getDefaultTablePath( datasetName, imageName ) );
+
+        // delete files
+        for ( File file : new File[] {xmlFile, tableFile}) {
+            if ( file != null && file.exists() ) {
+                Files.delete( file.toPath() );
+            }
+        }
+
+        // delete directories
+        for ( File file : new File[]{ zarrFile, n5File }) {
+            if ( file != null && file.exists() ) {
+                FileUtils.deleteDirectory( file );
+            }
+        }
+    }
+
     public void addBdvFormatImage ( File fileLocation, String datasetName, ProjectCreator.ImageType imageType,
                                     ProjectCreator.AddMethod addMethod, String uiSelectionGroup,
                                     ImageDataFormat imageDataFormat, boolean exclusive ) throws SpimDataException, IOException {
@@ -252,6 +303,7 @@ public class ImagesCreator {
 
             if ( newImageFile.exists() ) {
                 IJ.log("Overwriting image " + imageName + " in dataset " + datasetName );
+                deleteImageFiles( datasetName, imageName, imageDataFormat );
             }
 
             // make directory for that image file format, if doesn't exist already
@@ -344,7 +396,7 @@ public class ImagesCreator {
     // TODO - is this efficient for big images?
     private void addDefaultTableForImage ( String imageName, String datasetName, ImageDataFormat imageDataFormat ) {
         File tableFolder = new File( getDefaultTableDirPath( datasetName, imageName ) );
-        File defaultTable = new File( tableFolder, "default.tsv" );
+        File defaultTable = new File( getDefaultTablePath( datasetName, imageName ) );
         if ( !tableFolder.exists() ){
             tableFolder.mkdirs();
         }

--- a/src/main/java/org/embl/mobie/viewer/projectcreator/ImagesCreator.java
+++ b/src/main/java/org/embl/mobie/viewer/projectcreator/ImagesCreator.java
@@ -276,14 +276,13 @@ public class ImagesCreator {
         }
     }
 
-    public void addBdvFormatImage ( File fileLocation, String datasetName, ProjectCreator.ImageType imageType,
-                                    ProjectCreator.AddMethod addMethod, String uiSelectionGroup,
-                                    ImageDataFormat imageDataFormat, boolean exclusive ) throws SpimDataException, IOException {
+    public void addBdvFormatImage ( File fileLocation, String imageName, String datasetName,
+                                    ProjectCreator.ImageType imageType, ProjectCreator.AddMethod addMethod,
+                                    String uiSelectionGroup, ImageDataFormat imageDataFormat, boolean exclusive ) throws SpimDataException, IOException {
 
         if ( fileLocation.exists() ) {
 
             SpimData spimData = ( SpimData ) new SpimDataOpener().openSpimData( fileLocation.getAbsolutePath(), imageDataFormat );
-            String imageName = fileLocation.getName().split("\\.")[0];
             File imageDirectory = new File( getDefaultLocalImageDirPath( datasetName, imageDataFormat ));
 
             File newImageFile = null;

--- a/src/main/java/org/embl/mobie/viewer/projectcreator/ImagesCreator.java
+++ b/src/main/java/org/embl/mobie/viewer/projectcreator/ImagesCreator.java
@@ -314,6 +314,7 @@ public class ImagesCreator {
             switch (addMethod) {
                 case link:
                     // TODO - linking currently not supported for ome-zarr
+                    spimData.setBasePath( imageDir );
                     new XmlIoSpimData().save(spimData, newImageFile.getAbsolutePath());
                     break;
                 case copy:

--- a/src/main/java/org/embl/mobie/viewer/projectcreator/ui/ManualExportPanel.java
+++ b/src/main/java/org/embl/mobie/viewer/projectcreator/ui/ManualExportPanel.java
@@ -2,16 +2,10 @@ package org.embl.mobie.viewer.projectcreator.ui;
 
 import bdv.ij.util.PluginHelper;
 import org.embl.mobie.io.ImageDataFormat;
-import org.embl.mobie.io.n5.util.DownsampleBlock;
-import org.embl.mobie.io.n5.writers.WriteImgPlusToN5;
-import org.embl.mobie.io.ome.zarr.writers.imgplus.WriteImgPlusToN5BdvOmeZarr;
-import org.embl.mobie.io.ome.zarr.writers.imgplus.WriteImgPlusToN5OmeZarr;
 
 import fiji.util.gui.GenericDialogPlus;
 import ij.IJ;
-import ij.ImagePlus;
 import ij.gui.GenericDialog;
-import net.imglib2.realtransform.AffineTransform3D;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream;
 import org.janelia.saalfeldlab.n5.*;
 
@@ -22,28 +16,16 @@ public class ManualExportPanel {
 
     static { net.imagej.patcher.LegacyInjector.preinit(); }
 
-    ImagePlus imp;
-    String filePath;
-    AffineTransform3D sourceTransform;
-    DownsampleBlock.DownsamplingMethod downsamplingMethod;
-    String imageName;
-    ImageDataFormat imageDataFormat;
+    private int[][] subdivisions;
+    private int[][] resolutions;
+    private Compression compression;
 
     static String lastSubsampling = "{ {1,1,1} }";
     static String lastChunkSizes = "{ {64,64,64} }";
     static int lastCompressionChoice = 0;
     static boolean lastCompressionDefaultSettings = true;
 
-    public ManualExportPanel(ImagePlus imp, String filePath, AffineTransform3D sourceTransform, DownsampleBlock.DownsamplingMethod downsamplingMethod, String imageName, ImageDataFormat imageDataFormat ) {
-        this.imp = imp;
-        this.filePath = filePath;
-        this.sourceTransform = sourceTransform;
-        this.downsamplingMethod = downsamplingMethod;
-        this.imageName = imageName;
-        this.imageDataFormat = imageDataFormat;
-    }
-
-    public void getManualExportParameters() {
+    public ManualExportPanel( ImageDataFormat imageDataFormat ) {
 
         final GenericDialog manualSettings = new GenericDialog( "Manual Settings for " +
                 imageDataFormat.toString() );
@@ -67,6 +49,9 @@ public class ManualExportPanel {
         if ( !manualSettings.wasCanceled() ) {
             lastSubsampling = manualSettings.getNextString();
             lastChunkSizes = manualSettings.getNextString();
+
+            subdivisions = PluginHelper.parseResolutionsString( lastChunkSizes );
+            resolutions = PluginHelper.parseResolutionsString( lastSubsampling );
             if ( imageDataFormat == ImageDataFormat.BdvN5 ) {
                 lastCompressionChoice = manualSettings.getNextChoiceIndex();
                 lastCompressionDefaultSettings = manualSettings.getNextBoolean();
@@ -74,18 +59,27 @@ public class ManualExportPanel {
                 lastCompressionChoice = 2;
                 lastCompressionDefaultSettings = true;
             }
-
-            parseInputAndWriteImage();
+            parseCompression();
+        } else {
+            subdivisions = null;
+            resolutions = null;
+            compression = null;
         }
-
     }
 
-    private void parseInputAndWriteImage() {
-        // parse mipmap resolutions and cell sizes
-        final int[][] resolutions = PluginHelper.parseResolutionsString( lastSubsampling );
-        final int[][] subdivisions = PluginHelper.parseResolutionsString( lastChunkSizes );
+    public int[][] getSubdivisions() {
+        return subdivisions;
+    }
 
-        final Compression compression;
+    public int[][] getResolutions() {
+        return resolutions;
+    }
+
+    public Compression getCompression() {
+        return compression;
+    }
+
+    private void parseCompression(){
         switch ( lastCompressionChoice )
         {
             default:
@@ -112,32 +106,6 @@ public class ManualExportPanel {
                         ? new XzCompression()
                         : getXzSettings();
                 break;
-        }
-        if ( compression == null )
-            return;
-
-        writeImage( resolutions, subdivisions, compression );
-    }
-
-    private void writeImage( int[][] resolutions, int[][] subdivisions, Compression compression ) {
-        switch( imageDataFormat ) {
-            case BdvN5:
-                new WriteImgPlusToN5().export(imp, resolutions, subdivisions, filePath, sourceTransform,
-                        downsamplingMethod, compression, new String[]{imageName});
-                break;
-
-            case BdvOmeZarr:
-                new WriteImgPlusToN5BdvOmeZarr().export(imp, resolutions, subdivisions, filePath, sourceTransform,
-                        downsamplingMethod, compression, new String[]{imageName});
-                break;
-
-            case OmeZarr:
-                new WriteImgPlusToN5OmeZarr().export(imp, resolutions, subdivisions, filePath, sourceTransform,
-                        downsamplingMethod, compression, new String[]{imageName});
-                break;
-
-            default:
-                throw new UnsupportedOperationException();
         }
     }
 

--- a/src/main/java/org/embl/mobie/viewer/projectcreator/ui/ProjectsCreatorPanel.java
+++ b/src/main/java/org/embl/mobie/viewer/projectcreator/ui/ProjectsCreatorPanel.java
@@ -19,6 +19,7 @@ import net.imglib2.realtransform.AffineTransform3D;
 import org.embl.mobie.viewer.projectcreator.ProjectCreatorHelper;
 import org.embl.mobie.viewer.ui.SwingHelper;
 import org.embl.mobie.viewer.ui.UserInterfaceHelper;
+import org.janelia.saalfeldlab.n5.Compression;
 
 import javax.swing.*;
 import java.awt.*;
@@ -480,15 +481,31 @@ public class ProjectsCreatorPanel extends JFrame {
                     if ( imagesCreator.imageExists( datasetName, imageName, imageDataFormat ) ) {
                         overwriteImage = overwriteImageDialog();
                     }
+                    if ( !overwriteImage ) {
+                        return;
+                    }
 
-                    if ( overwriteImage ) {
-                        String uiSelectionGroup = null;
-                        uiSelectionGroup = selectUiSelectionGroupDialog(datasetName);
-                        if (uiSelectionGroup != null) {
-                            imagesCreator.addImage(currentImage, imageName,
-                                    datasetName, imageDataFormat, imageType, sourceTransform, useDefaultExportSettings,
-                                    uiSelectionGroup, exclusive);
-                            updateComboBoxesForNewImage(imageName, uiSelectionGroup);
+                    String uiSelectionGroup = null;
+                    uiSelectionGroup = selectUiSelectionGroupDialog(datasetName);
+                    if ( uiSelectionGroup == null ) {
+                        return;
+                    }
+
+                    if ( useDefaultExportSettings ) {
+                        imagesCreator.addImage(currentImage, imageName, datasetName, imageDataFormat,
+                                imageType, sourceTransform, uiSelectionGroup, exclusive);
+                        updateComboBoxesForNewImage(imageName, uiSelectionGroup);
+                    } else {
+                        ManualExportPanel manualExportPanel = new ManualExportPanel( imageDataFormat );
+                        int[][] resolutions = manualExportPanel.getResolutions();
+                        int[][] subdivisions = manualExportPanel.getSubdivisions();
+                        Compression compression = manualExportPanel.getCompression();
+
+                        if ( resolutions != null && subdivisions != null && compression != null ) {
+                            imagesCreator.addImage( currentImage, imageName, datasetName, imageDataFormat, imageType,
+                                    sourceTransform, uiSelectionGroup, exclusive, resolutions, subdivisions,
+                                    compression );
+                            updateComboBoxesForNewImage( imageName, uiSelectionGroup );
                         }
                     }
                 }

--- a/src/main/java/org/embl/mobie/viewer/projectcreator/ui/ProjectsCreatorPanel.java
+++ b/src/main/java/org/embl/mobie/viewer/projectcreator/ui/ProjectsCreatorPanel.java
@@ -491,22 +491,26 @@ public class ProjectsCreatorPanel extends JFrame {
                         return;
                     }
 
-                    if ( useDefaultExportSettings ) {
-                        imagesCreator.addImage(currentImage, imageName, datasetName, imageDataFormat,
-                                imageType, sourceTransform, uiSelectionGroup, exclusive);
-                        updateComboBoxesForNewImage(imageName, uiSelectionGroup);
-                    } else {
-                        ManualExportPanel manualExportPanel = new ManualExportPanel( imageDataFormat );
-                        int[][] resolutions = manualExportPanel.getResolutions();
-                        int[][] subdivisions = manualExportPanel.getSubdivisions();
-                        Compression compression = manualExportPanel.getCompression();
+                    try {
+                        if ( useDefaultExportSettings ) {
+                            imagesCreator.addImage(currentImage, imageName, datasetName, imageDataFormat,
+                                    imageType, sourceTransform, uiSelectionGroup, exclusive);
+                            updateComboBoxesForNewImage(imageName, uiSelectionGroup);
+                        } else {
+                            ManualExportPanel manualExportPanel = new ManualExportPanel( imageDataFormat );
+                            int[][] resolutions = manualExportPanel.getResolutions();
+                            int[][] subdivisions = manualExportPanel.getSubdivisions();
+                            Compression compression = manualExportPanel.getCompression();
 
-                        if ( resolutions != null && subdivisions != null && compression != null ) {
-                            imagesCreator.addImage( currentImage, imageName, datasetName, imageDataFormat, imageType,
-                                    sourceTransform, uiSelectionGroup, exclusive, resolutions, subdivisions,
-                                    compression );
-                            updateComboBoxesForNewImage( imageName, uiSelectionGroup );
+                            if ( resolutions != null && subdivisions != null && compression != null ) {
+                                imagesCreator.addImage( currentImage, imageName, datasetName, imageDataFormat, imageType,
+                                        sourceTransform, uiSelectionGroup, exclusive, resolutions, subdivisions,
+                                        compression );
+                                updateComboBoxesForNewImage( imageName, uiSelectionGroup );
+                            }
                         }
+                    } catch (SpimDataException | IOException e) {
+                        e.printStackTrace();
                     }
                 }
             }
@@ -578,19 +582,22 @@ public class ProjectsCreatorPanel extends JFrame {
                     if ( imagesCreator.imageExists( datasetName, imageName, imageDataFormat ) ) {
                         overwriteImage = overwriteImageDialog();
                     }
+                    if ( !overwriteImage ) {
+                        return;
+                    }
 
-                    if ( overwriteImage ) {
-                        try {
-                            String uiSelectionGroup = null;
-                            uiSelectionGroup = selectUiSelectionGroupDialog(datasetName);
-                            if (uiSelectionGroup != null) {
-                                imagesCreator.addBdvFormatImage(imageFile, datasetName, imageType,
-                                        addMethod, uiSelectionGroup, imageDataFormat, exclusive);
-                                updateComboBoxesForNewImage(imageName, uiSelectionGroup);
-                            }
-                        } catch (SpimDataException | IOException e) {
-                            e.printStackTrace();
-                        }
+                    String uiSelectionGroup = null;
+                    uiSelectionGroup = selectUiSelectionGroupDialog(datasetName);
+                    if ( uiSelectionGroup == null ) {
+                        return;
+                    }
+
+                    try {
+                            imagesCreator.addBdvFormatImage(imageFile, datasetName, imageType,
+                                    addMethod, uiSelectionGroup, imageDataFormat, exclusive);
+                            updateComboBoxesForNewImage(imageName, uiSelectionGroup);
+                    } catch (SpimDataException | IOException e) {
+                        e.printStackTrace();
                     }
                 }
             }

--- a/src/test/java/org/embl/mobie/viewer/projectcreator/ImagesCreatorTest.java
+++ b/src/test/java/org/embl/mobie/viewer/projectcreator/ImagesCreatorTest.java
@@ -39,7 +39,6 @@ class ImagesCreatorTest {
     private String imageName;
     private String datasetName;
     private AffineTransform3D sourceTransform;
-    private boolean useDefaultSettings;
     private String uiSelectionGroup;
     private String datasetJsonPath;
     private File tempDir;
@@ -54,7 +53,6 @@ class ImagesCreatorTest {
         datasetName = "test";
         uiSelectionGroup = "testGroup";
         sourceTransform = new AffineTransform3D();
-        useDefaultSettings = true;
 
         projectCreator.getDatasetsCreator().addDataset(datasetName);
 
@@ -158,7 +156,7 @@ class ImagesCreatorTest {
 
         imagesCreator.addImage( imp, imageName, datasetName,
                 imageDataFormat, ProjectCreator.ImageType.image,
-                sourceTransform, useDefaultSettings, uiSelectionGroup, false );
+                sourceTransform, uiSelectionGroup, false );
 
         assertionsForImageAdded( imageDataFormat, false );
     }
@@ -168,7 +166,7 @@ class ImagesCreatorTest {
 
         imagesCreator.addImage( seg, imageName, datasetName,
                 imageDataFormat, ProjectCreator.ImageType.segmentation,
-                sourceTransform, useDefaultSettings, uiSelectionGroup, false );
+                sourceTransform, uiSelectionGroup, false );
 
         assertionsForImageAdded( imageDataFormat, false );
         assertionsForTableAdded( imageDataFormat );

--- a/src/test/java/org/embl/mobie/viewer/projectcreator/ImagesCreatorTest.java
+++ b/src/test/java/org/embl/mobie/viewer/projectcreator/ImagesCreatorTest.java
@@ -177,7 +177,7 @@ class ImagesCreatorTest {
         // save example image
         String filePath = writeImageAndGetPath( imageDataFormat );
 
-        imagesCreator.addBdvFormatImage( new File(filePath), datasetName, ProjectCreator.ImageType.image,
+        imagesCreator.addBdvFormatImage( new File(filePath), imageName, datasetName, ProjectCreator.ImageType.image,
                 ProjectCreator.AddMethod.link, uiSelectionGroup, imageDataFormat, false );
 
         assertionsForImageAdded( imageDataFormat, true );
@@ -188,7 +188,7 @@ class ImagesCreatorTest {
         // save example image
         String filePath = writeImageAndGetPath( imageDataFormat );
 
-        imagesCreator.addBdvFormatImage( new File(filePath), datasetName, ProjectCreator.ImageType.image,
+        imagesCreator.addBdvFormatImage( new File(filePath), imageName, datasetName, ProjectCreator.ImageType.image,
                 ProjectCreator.AddMethod.copy, uiSelectionGroup, imageDataFormat, false );
 
         assertionsForImageAdded( imageDataFormat, false );
@@ -199,7 +199,7 @@ class ImagesCreatorTest {
         // save example image
         String filePath = writeImageAndGetPath( imageDataFormat );
 
-        imagesCreator.addBdvFormatImage( new File(filePath), datasetName, ProjectCreator.ImageType.image,
+        imagesCreator.addBdvFormatImage( new File(filePath), imageName, datasetName, ProjectCreator.ImageType.image,
                 ProjectCreator.AddMethod.move, uiSelectionGroup, imageDataFormat, false );
 
         assertionsForImageAdded( imageDataFormat, false );

--- a/src/test/java/org/embl/mobie/viewer/projectcreator/ImagesCreatorTest.java
+++ b/src/test/java/org/embl/mobie/viewer/projectcreator/ImagesCreatorTest.java
@@ -149,7 +149,7 @@ class ImagesCreatorTest {
         return filePath;
     }
 
-    void testAddingImageInCertainFormat( ImageDataFormat imageDataFormat ) throws IOException {
+    void testAddingImageInCertainFormat( ImageDataFormat imageDataFormat ) throws IOException, SpimDataException {
 
         // make an image with random values, same size as the imagej sample head image
         ImagePlus imp = makeImage( imageName );
@@ -161,7 +161,7 @@ class ImagesCreatorTest {
         assertionsForImageAdded( imageDataFormat, false );
     }
 
-    void testAddingSegmentationInCertainFormat( ImageDataFormat imageDataFormat ) throws IOException {
+    void testAddingSegmentationInCertainFormat( ImageDataFormat imageDataFormat ) throws IOException, SpimDataException {
         ImagePlus seg = makeSegmentation( imageName );
 
         imagesCreator.addImage( seg, imageName, datasetName,
@@ -206,32 +206,32 @@ class ImagesCreatorTest {
     }
 
     @Test
-    void addImageBdvN5() throws IOException {
+    void addImageBdvN5() throws IOException, SpimDataException {
         testAddingImageInCertainFormat( ImageDataFormat.BdvN5 );
     }
 
     @Test
-    void addSegmentationBdvN5() throws IOException {
+    void addSegmentationBdvN5() throws IOException, SpimDataException {
         testAddingSegmentationInCertainFormat( ImageDataFormat.BdvN5 );
     }
 
     @Test
-    void addImageBdvOmeZarr() throws IOException {
+    void addImageBdvOmeZarr() throws IOException, SpimDataException {
         testAddingImageInCertainFormat( ImageDataFormat.BdvOmeZarr );
     }
 
     @Test
-    void addSegmentationBdvOmeZarr() throws IOException {
+    void addSegmentationBdvOmeZarr() throws IOException, SpimDataException {
         testAddingSegmentationInCertainFormat( ImageDataFormat.BdvOmeZarr );
     }
 
     @Test
-    void addImageOmeZarr() throws IOException {
+    void addImageOmeZarr() throws IOException, SpimDataException {
         testAddingImageInCertainFormat( ImageDataFormat.OmeZarr );
     }
 
     @Test
-    void addSegmentationOmeZarr() throws IOException {
+    void addSegmentationOmeZarr() throws IOException, SpimDataException {
         testAddingSegmentationInCertainFormat( ImageDataFormat.OmeZarr );
     }
 

--- a/src/test/java/org/embl/mobie/viewer/projectcreator/RemoteMetadataCreatorTest.java
+++ b/src/test/java/org/embl/mobie/viewer/projectcreator/RemoteMetadataCreatorTest.java
@@ -1,5 +1,6 @@
 package org.embl.mobie.viewer.projectcreator;
 
+import mpicbg.spim.data.SpimDataException;
 import org.embl.mobie.io.ImageDataFormat;
 import org.embl.mobie.viewer.Dataset;
 import org.embl.mobie.viewer.serialize.DatasetJsonParser;
@@ -42,7 +43,7 @@ class RemoteMetadataCreatorTest {
                 datasetName, "dataset.json" );
     }
 
-    void testAddingRemoteMetadataForCertainFormat( ImageDataFormat imageDataFormat ) throws IOException {
+    void testAddingRemoteMetadataForCertainFormat( ImageDataFormat imageDataFormat ) throws IOException, SpimDataException {
 
         // add image of right type
         projectCreator.getImagesCreator().addImage( ProjectCreatorTestHelper.makeImage(imageName), imageName,
@@ -76,17 +77,17 @@ class RemoteMetadataCreatorTest {
     }
 
     @Test
-    void createRemoteMetadataBdvN5() throws IOException {
+    void createRemoteMetadataBdvN5() throws IOException, SpimDataException {
         testAddingRemoteMetadataForCertainFormat( ImageDataFormat.BdvN5 );
     }
 
     @Test
-    void createRemoteMetadataBdvOmeZarr() throws IOException {
+    void createRemoteMetadataBdvOmeZarr() throws IOException, SpimDataException {
         testAddingRemoteMetadataForCertainFormat( ImageDataFormat.BdvOmeZarr );
     }
 
     @Test
-    void createRemoteMetadataOmeZarr() throws IOException {
+    void createRemoteMetadataOmeZarr() throws IOException, SpimDataException {
         testAddingRemoteMetadataForCertainFormat( ImageDataFormat.OmeZarr);
     }
 }

--- a/src/test/java/org/embl/mobie/viewer/projectcreator/RemoteMetadataCreatorTest.java
+++ b/src/test/java/org/embl/mobie/viewer/projectcreator/RemoteMetadataCreatorTest.java
@@ -47,7 +47,7 @@ class RemoteMetadataCreatorTest {
         // add image of right type
         projectCreator.getImagesCreator().addImage( ProjectCreatorTestHelper.makeImage(imageName), imageName,
                 datasetName, imageDataFormat, ProjectCreator.ImageType.image, new AffineTransform3D(),
-                true, uiSelectionGroup, false );
+                uiSelectionGroup, false );
 
         ImageDataFormat remoteFormat = null;
         switch( imageDataFormat ) {


### PR DESCRIPTION
Fixes https://github.com/mobie/mobie-viewer-fiji/issues/589

Main changes:
- allows images to be overwritten in the project creator
- separates the last of the project creator ui from the actual api (e.g. manual export) for https://github.com/mobie/mobie-viewer-fiji/issues/591
- allows changing the name of bdv format images when added to project
- fixes bug with linking to bdv format images