### PR TITLE
Add project creator affine to view, not xml

### DIFF
--- a/src/main/java/org/embl/mobie/viewer/projectcreator/ImagesCreator.java
+++ b/src/main/java/org/embl/mobie/viewer/projectcreator/ImagesCreator.java
@@ -120,6 +120,44 @@ public class ImagesCreator {
 
     public void addImage ( ImagePlus imp, String imageName, String datasetName,
                            ImageDataFormat imageDataFormat, ProjectCreator.ImageType imageType,
+                           String uiSelectionGroup, boolean exclusive ) throws SpimDataException, IOException {
+        addImage( imp, imageName, datasetName, imageDataFormat, imageType, new AffineTransform3D(), uiSelectionGroup,
+                exclusive, null, null, null );
+
+    }
+
+    public void addImage ( ImagePlus imp, String imageName, String datasetName,
+                           ImageDataFormat imageDataFormat, ProjectCreator.ImageType imageType,
+                           String uiSelectionGroup, boolean exclusive,
+                           int[][] resolutions, int[][] subdivisions, Compression compression ) throws SpimDataException, IOException {
+        addImage( imp, imageName, datasetName, imageDataFormat, imageType, new AffineTransform3D(), uiSelectionGroup,
+                exclusive, resolutions, subdivisions, compression );
+    }
+
+    /**
+     * Add an image to a MoBIE project. Make sure the ImagePlus scale is set properly, so that imp.getCalibration()
+     * returns the correct values. Note that multi-channel images are not supported - you will need to
+     * split these channels and add each as its own image.
+     * @param imp image to add
+     * @param imageName image name
+     * @param datasetName dataset name
+     * @param imageDataFormat image format
+     * @param imageType Image or Segmentation - segmentations will additionally generate a table.
+     * @param sourceTransform Affine transform - this will be added to the image view, and will be added on top
+     *                        of the normal scaling coming from imp.getCalibration()
+     * @param uiSelectionGroup Name of MoBIE drop-down menu to place view in
+     * @param exclusive Whether to make the view exclusive.
+     * @param resolutions Resolution/downsampling levels to write e.g. new int[][]{ {1,1,1}, {2,2,2}, {4,4,4} }
+     *                    will write one full resolution level, then one 2x downsampled, and one 4x downsampled.
+     *                    The order is {x, y, z}.
+     * @param subdivisions Chunk size. Must have the same number of entries as 'resolutions'. e.g.
+     *                     new int[][]{ {64,64,64}, {64,64,64}, {64,64,64} }. The order is {x, y, z}.
+     * @param compression type of compression to use
+     * @throws SpimDataException
+     * @throws IOException
+     */
+    public void addImage ( ImagePlus imp, String imageName, String datasetName,
+                           ImageDataFormat imageDataFormat, ProjectCreator.ImageType imageType,
                            AffineTransform3D sourceTransform, String uiSelectionGroup, boolean exclusive,
                            int[][] resolutions, int[][] subdivisions, Compression compression ) throws IOException, SpimDataException {
         // either xml file path or zarr file path depending on imageDataFormat
@@ -139,9 +177,9 @@ public class ImagesCreator {
         }
 
         if ( resolutions == null || subdivisions == null || compression == null ) {
-            writeDefaultImage( imp, filePath, sourceTransform, downsamplingMethod, imageName, imageDataFormat );
+            writeDefaultImage( imp, filePath, downsamplingMethod, imageName, imageDataFormat );
         } else {
-            writeDefaultImage( imp, filePath, sourceTransform, downsamplingMethod, imageName, imageDataFormat,
+            writeDefaultImage( imp, filePath, downsamplingMethod, imageName, imageDataFormat,
                     resolutions, subdivisions, compression );
         }
 
@@ -158,11 +196,11 @@ public class ImagesCreator {
                 LUT lut = imp.getLuts()[0];
                 String colour = "r=" + lut.getRed(255) + ",g=" + lut.getGreen(255) + ",b=" +
                         lut.getBlue(255) + ",a=" + lut.getAlpha(255);
-                updateTableAndJsonsForNewImage(imageName, datasetName, uiSelectionGroup, is2D,
-                        imp.getNFrames(), imageDataFormat, contrastLimits, colour, exclusive );
+                updateTableAndJsonsForNewImage( imageName, datasetName, uiSelectionGroup, is2D,
+                        imp.getNFrames(), imageDataFormat, contrastLimits, colour, exclusive, sourceTransform );
             } else {
                 updateTableAndJsonsForNewSegmentation(imageName, datasetName, uiSelectionGroup, is2D,
-                        imp.getNFrames(), imageDataFormat, exclusive );
+                        imp.getNFrames(), imageDataFormat, exclusive, sourceTransform );
             }
         }
 
@@ -181,9 +219,12 @@ public class ImagesCreator {
         return downsamplingMethod;
     }
 
-    private void writeDefaultImage( ImagePlus imp, String filePath, AffineTransform3D sourceTransform,
+    private void writeDefaultImage( ImagePlus imp, String filePath,
                                     DownsampleBlock.DownsamplingMethod downsamplingMethod,
                                     String imageName, ImageDataFormat imageDataFormat ) {
+
+        // transform only including scaling from image
+        AffineTransform3D sourceTransform = ProjectCreatorHelper.generateDefaultAffine( imp );
 
         // gzip compression by default
         switch( imageDataFormat ) {
@@ -208,10 +249,13 @@ public class ImagesCreator {
         }
     }
 
-    private void writeDefaultImage( ImagePlus imp, String filePath, AffineTransform3D sourceTransform,
+    private void writeDefaultImage( ImagePlus imp, String filePath,
                              DownsampleBlock.DownsamplingMethod downsamplingMethod,
                              String imageName, ImageDataFormat imageDataFormat,
                              int[][] resolutions, int[][] subdivisions, Compression compression ) {
+
+        // transform only including scaling from image
+        AffineTransform3D sourceTransform = ProjectCreatorHelper.generateDefaultAffine( imp );
 
         switch( imageDataFormat ) {
             case BdvN5:
@@ -328,10 +372,11 @@ public class ImagesCreator {
             if (imageType == ProjectCreator.ImageType.image) {
                 updateTableAndJsonsForNewImage( imageName, datasetName, uiSelectionGroup,
                         isSpimData2D(spimData), getNTimepointsFromSpimData(spimData),
-                        imageDataFormat, new double[]{0.0, 255.0}, "white", exclusive );
+                        imageDataFormat, new double[]{0.0, 255.0}, "white", exclusive, new AffineTransform3D() );
             } else {
                 updateTableAndJsonsForNewSegmentation( imageName, datasetName, uiSelectionGroup,
-                        isSpimData2D(spimData), getNTimepointsFromSpimData(spimData), imageDataFormat, exclusive );
+                        isSpimData2D(spimData), getNTimepointsFromSpimData(spimData), imageDataFormat, exclusive,
+                        new AffineTransform3D() );
             }
 
             IJ.log( "Bdv format image " + imageName + " added to project" );
@@ -458,19 +503,19 @@ public class ImagesCreator {
     private void updateTableAndJsonsForNewImage ( String imageName, String datasetName, String uiSelectionGroup,
                                                   boolean is2D, int nTimepoints, ImageDataFormat imageDataFormat,
                                                   double[] contrastLimits, String colour,
-                                                  boolean exclusive ) throws SpimDataException {
+                                                  boolean exclusive, AffineTransform3D sourceTransform ) {
         DatasetJsonCreator datasetJsonCreator = projectCreator.getDatasetJsonCreator();
         datasetJsonCreator.addImageToDatasetJson( imageName, datasetName, uiSelectionGroup, is2D, nTimepoints,
-                imageDataFormat, contrastLimits, colour, exclusive );
+                imageDataFormat, contrastLimits, colour, exclusive, sourceTransform );
     }
 
     private void updateTableAndJsonsForNewSegmentation( String imageName, String datasetName, String uiSelectionGroup,
                                                         boolean is2D, int nTimepoints, ImageDataFormat imageDataFormat,
-                                                        boolean exclusive ) {
+                                                        boolean exclusive, AffineTransform3D sourceTransform ) {
         addDefaultTableForImage( imageName, datasetName, imageDataFormat );
         DatasetJsonCreator datasetJsonCreator = projectCreator.getDatasetJsonCreator();
         datasetJsonCreator.addSegmentationToDatasetJson( imageName, datasetName, uiSelectionGroup, is2D, nTimepoints,
-                imageDataFormat, exclusive );
+                imageDataFormat, exclusive, sourceTransform );
     }
 
     private void copyImage ( ImageDataFormat imageFormat, SpimData spimData,
@@ -602,40 +647,6 @@ public class ImagesCreator {
         spimData.setBasePath( saveDirectory );
         spimData.getSequenceDescription().setImgLoader(imgLoader);
         new XmlIoSpimData().save(spimData, new File( saveDirectory, imageName + ".xml").getAbsolutePath() );
-    }
-
-    private void addAffineTransformToXml ( String xmlPath, String affineTransform )  {
-        if ( affineTransform != null ) {
-            try {
-                SpimDataMinimal spimDataMinimal = new XmlIoSpimDataMinimal().load( xmlPath );
-                int numTimepoints = spimDataMinimal.getSequenceDescription().getTimePoints().size();
-                int numSetups = spimDataMinimal.getSequenceDescription().getViewSetupsOrdered().size();
-
-                AffineTransform3D sourceTransform = new AffineTransform3D();
-                String[] splitAffineTransform = affineTransform.split(" ");
-                double[] doubleAffineTransform = new double[splitAffineTransform.length];
-                for ( int i = 0; i < splitAffineTransform.length; i++ ) {
-                    doubleAffineTransform[i] = Double.parseDouble( splitAffineTransform[i] );
-                }
-                sourceTransform.set( doubleAffineTransform );
-
-                final ArrayList<ViewRegistration> registrations = new ArrayList<>();
-                for ( int t = 0; t < numTimepoints; ++t ) {
-                    for (int s = 0; s < numSetups; ++s) {
-                        registrations.add(new ViewRegistration(t, s, sourceTransform));
-                    }
-                }
-
-                SpimDataMinimal updatedSpimDataMinimial = new SpimDataMinimal(spimDataMinimal.getBasePath(),
-                        spimDataMinimal.getSequenceDescription(), new ViewRegistrations( registrations) );
-
-                new XmlIoSpimDataMinimal().save( updatedSpimDataMinimial, xmlPath);
-            } catch (SpimDataException e) {
-                IJ.log( "Error adding affine transform to xml file. Check xml manually.");
-                e.printStackTrace();
-            }
-
-        }
     }
 
 }

--- a/src/main/java/org/embl/mobie/viewer/projectcreator/ProjectCreatorHelper.java
+++ b/src/main/java/org/embl/mobie/viewer/projectcreator/ProjectCreatorHelper.java
@@ -56,12 +56,12 @@ public class ProjectCreatorHelper {
     }
 
     public static boolean isValidAffine(String affine) {
-        if (!affine.matches("^[0-9. ]+$")) {
-            IJ.log("Invalid affine transform - must contain only numbers and spaces");
+        if (!affine.matches("^[0-9., ]+$")) {
+            IJ.log("Invalid affine transform - must contain only numbers, commas and spaces");
             return false;
         }
 
-        String[] splitAffine = affine.split(" ");
+        String[] splitAffine = affine.split(",");
         if (splitAffine.length != 12) {
             IJ.log("Invalid affine transform - must be of length 12");
             return false;
@@ -73,7 +73,9 @@ public class ProjectCreatorHelper {
     public static AffineTransform3D parseAffineString(String affine) {
         if (isValidAffine(affine)) {
             AffineTransform3D sourceTransform = new AffineTransform3D();
-            String[] splitAffineTransform = affine.split(" ");
+            // remove spaces
+            affine = affine.replaceAll("\\s","");
+            String[] splitAffineTransform = affine.split(",");
             double[] doubleAffineTransform = new double[splitAffineTransform.length];
             for (int i = 0; i < splitAffineTransform.length; i++) {
                 doubleAffineTransform[i] = Double.parseDouble(splitAffineTransform[i]);
@@ -85,12 +87,14 @@ public class ProjectCreatorHelper {
         }
     }
 
-    public static String generateDefaultAffine(ImagePlus imp) {
+    public static AffineTransform3D generateDefaultAffine(ImagePlus imp) {
         final double pixelWidth = imp.getCalibration().pixelWidth;
         final double pixelHeight = imp.getCalibration().pixelHeight;
         final double pixelDepth = imp.getCalibration().pixelDepth;
 
-        String defaultAffine = pixelWidth + " 0.0 0.0 0.0 0.0 " + pixelHeight + " 0.0 0.0 0.0 0.0 " + pixelDepth + " 0.0";
+        AffineTransform3D defaultAffine = new AffineTransform3D();
+        defaultAffine.scale( pixelWidth, pixelHeight, pixelDepth );
+
         return defaultAffine;
     }
 

--- a/src/main/java/org/embl/mobie/viewer/projectcreator/ui/ProjectsCreatorPanel.java
+++ b/src/main/java/org/embl/mobie/viewer/projectcreator/ui/ProjectsCreatorPanel.java
@@ -464,16 +464,19 @@ public class ProjectsCreatorPanel extends JFrame {
 
         if ( !datasetName.equals("") ) {
             ImagePlus currentImage = IJ.getImage();
-            String defaultAffineTransform = ProjectCreatorHelper.generateDefaultAffine( currentImage );
 
             final GenericDialog gd = new GenericDialog( "Add Current Image To MoBIE Project..." );
             gd.addMessage( "Make sure your pixel size, and unit,\n are set properly under Image > Properties...");
             gd.addStringField( "Image Name", FilenameUtils.removeExtension(currentImage.getTitle()), 35 );
             gd.addChoice( "Image Type", imageTypes, imageType.toString() );
             gd.addChoice( "Image format", imageFormats, imageDataFormat.toString() );
-            gd.addStringField("Affine", defaultAffineTransform, 35 );
             gd.addCheckbox("Use default export settings", useDefaultExportSettings );
             gd.addCheckbox("Make view exclusive", exclusive );
+
+            gd.addMessage("Affine transform:");
+            gd.addStringField("Row 1", "1.0, 0.0, 0.0, 0.0", 25 );
+            gd.addStringField( "Row 2", "0.0, 1.0, 0.0, 0.0", 25 );
+            gd.addStringField( "Row 3", "0.0, 0.0, 1.0, 0.0", 25 );
 
             gd.showDialog();
 
@@ -481,9 +484,13 @@ public class ProjectsCreatorPanel extends JFrame {
                 String imageName = gd.getNextString();
                 imageType = ProjectCreator.ImageType.valueOf( gd.getNextChoice() );
                 imageDataFormat = ImageDataFormat.fromString( gd.getNextChoice() );
-                String affineTransform = gd.getNextString().trim();
                 useDefaultExportSettings = gd.getNextBoolean();
                 exclusive = gd.getNextBoolean();
+
+                String affineRow1 = gd.getNextString().trim();
+                String affineRow2 = gd.getNextString().trim();
+                String affineRow3 = gd.getNextString().trim();
+                String affineTransform = String.join(",", affineRow1, affineRow2, affineRow3 );
 
                 // tidy up image name, remove any spaces
                 imageName = UserInterfaceHelper.tidyString( imageName );

--- a/src/main/java/org/embl/mobie/viewer/projectcreator/ui/ProjectsCreatorPanel.java
+++ b/src/main/java/org/embl/mobie/viewer/projectcreator/ui/ProjectsCreatorPanel.java
@@ -27,6 +27,7 @@ import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.io.File;
 import java.io.IOException;
+import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -459,6 +460,15 @@ public class ProjectsCreatorPanel extends JFrame {
         return imageName;
     }
 
+    private String getVoxelSizeString( ImagePlus imp ) {
+        DecimalFormat df = new DecimalFormat("#.###");
+        String voxelString =  "Voxel size: " + df.format( imp.getCalibration().pixelWidth ) + ", " +
+                df.format( imp.getCalibration().pixelHeight ) + ", " + df.format( imp.getCalibration().pixelDepth ) +
+                " " + imp.getCalibration().getUnit();
+
+        return voxelString;
+    }
+
     public void addCurrentOpenImageDialog() {
         String datasetName = (String) datasetComboBox.getSelectedItem();
 
@@ -472,14 +482,16 @@ public class ProjectsCreatorPanel extends JFrame {
             }
 
             final GenericDialog gd = new GenericDialog( "Add Current Image To MoBIE Project..." );
-            gd.addMessage( "Make sure your pixel size, and unit,\n are set properly under Image > Properties...");
+            gd.addMessage( "Make sure your voxel size, and unit,\n are set properly under Image > Properties...");
             gd.addStringField( "Image Name", FilenameUtils.removeExtension(currentImage.getTitle()), 35 );
             gd.addChoice( "Image Type", imageTypes, imageType.toString() );
             gd.addChoice( "Image format", imageFormats, imageDataFormat.toString() );
             gd.addCheckbox("Use default export settings", useDefaultExportSettings );
             gd.addCheckbox("Make view exclusive", exclusive );
 
-            gd.addMessage("Affine transform:");
+            gd.addMessage( getVoxelSizeString( currentImage ) );
+
+            gd.addMessage("Additional view affine transform:");
             gd.addStringField("Row 1", "1.0, 0.0, 0.0, 0.0", 25 );
             gd.addStringField( "Row 2", "0.0, 1.0, 0.0, 0.0", 25 );
             gd.addStringField( "Row 3", "0.0, 0.0, 1.0, 0.0", 25 );


### PR DESCRIPTION
Fixes https://github.com/mobie/mobie-viewer-fiji/issues/590 and https://github.com/mobie/mobie-viewer-fiji/issues/579
Main changes:
- Splits affine transform in ui into 3 rows
- Adds this affine to the view, not directly to the xml. Now the xml will always contain the scaling from the image itself (from imp.getCalibration()), and this affine will be added to the view on top.
![Screenshot 2022-02-14 160652](https://user-images.githubusercontent.com/24316371/153900798-607c4d54-edbb-4cbc-a662-dd157a2c62da.png)