### PR TITLE
Add MaskedSource

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
 		<!-- EMBL CBA -->
 		<imagej-utils.version>0.6.4</imagej-utils.version>
 
-		<mobie-io.version>1.2.2</mobie-io.version>
+		<mobie-io.version>1.2.3</mobie-io.version>
 
 		<!-- Version 1.6.0-scijava-3-SNAPSHOT of j3dcore addresses a minor issue
 		https://github.com/fiji/3D_Viewer/issues/26

--- a/src/main/java/org/embl/mobie/viewer/MoBIEUtils.java
+++ b/src/main/java/org/embl/mobie/viewer/MoBIEUtils.java
@@ -368,7 +368,7 @@ public abstract class MoBIEUtils
 		view.preConcatenate( translate.inverse() );
 
 		// divide by window width
-		final int bdvWindowWidth = BdvUtils.getBdvWindowWidth( bdv );
+		final int bdvWindowWidth = bdv.getBdvHandle().getViewerPanel().getDisplay().getWidth();
 		final Scale3D scale = new Scale3D( 1.0 / bdvWindowWidth, 1.0 / bdvWindowWidth, 1.0 / bdvWindowWidth );
 		view.preConcatenate( scale );
 

--- a/src/main/java/org/embl/mobie/viewer/bdv/BdvBoundingBoxDialog.java
+++ b/src/main/java/org/embl/mobie/viewer/bdv/BdvBoundingBoxDialog.java
@@ -66,33 +66,29 @@ public class BdvBoundingBoxDialog
         // viewer transform: physical to screen (0,0,w,h)
         this.boxTransform = bdvHandle.getViewerPanel().state().getViewerTransform();
 
-        // now: physical to screen with (-w/2,-h/2,w/2,h/2)
+        // physical to screen with (-w/2,-h/2,w/2,h/2)
         boxTransform.translate( -0.5 * bdvHandle.getViewerPanel().getDisplay().getWidth(), -0.5 * bdvHandle.getViewerPanel().getDisplay().getHeight(), 0 );
 
-        // remove the bdv window scale from the transform
+        // remove bdv window scale from transform
         // note that the scale of the viewer transform is uniform in 3-D
         // thus we can just pick either width or height
         final double scale = 1.0 / bdvHandle.getViewerPanel().getDisplay().getWidth();
-        final Scale3D scale3D = new Scale3D(
-                scale,
-                scale,
-                scale
-        );
+        final Scale3D scale3D = new Scale3D( scale, scale, scale );
         boxTransform.preConcatenate( scale3D );
 
+        // inverse: box to physical
+        boxTransform = boxTransform.inverse();
+
+        // check that it is correct (just for debugging)
         final double[] center = { 0, 0, 0 };
         final double[] left = { -0.5, -0.5, -0.5 };
         final double[] right = { 0.5, 0.5, 0.5 };
         final double[] physicalLeft = { 0, 0, 0 };
         final double[] physicalRight = { 0, 0, 0 };
         final double[] physicalCenter = { 0, 0, 0 };
-
-        // inverse viewer (box) transform: screen (box) to physical
-        boxTransform = boxTransform.inverse();
         boxTransform.apply( left, physicalLeft );
         boxTransform.apply( right, physicalRight );
         boxTransform.apply( center, physicalCenter );
-
     }
 
     public void showDialog()

--- a/src/main/java/org/embl/mobie/viewer/bdv/BdvBoundingBoxDialog.java
+++ b/src/main/java/org/embl/mobie/viewer/bdv/BdvBoundingBoxDialog.java
@@ -1,0 +1,144 @@
+/*-
+ * #%L
+ * Fiji plugin for inspection and processing of big image data
+ * %%
+ * Copyright (C) 2018 - 2021 EMBL
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.embl.mobie.viewer.bdv;
+
+import bdv.tools.boundingbox.BoxSelectionOptions;
+import bdv.tools.boundingbox.TransformedBoxSelectionDialog;
+import bdv.tools.boundingbox.TransformedRealBoxSelectionDialog;
+import bdv.util.Bdv;
+import bdv.util.BdvFunctions;
+import bdv.util.BdvHandle;
+import bdv.viewer.SourceAndConverter;
+import net.imglib2.FinalInterval;
+import net.imglib2.FinalRealInterval;
+import net.imglib2.Interval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.RealInterval;
+import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.util.Intervals;
+
+import java.util.List;
+
+public class BdvBoundingBoxDialog
+{
+    private Bdv bdvHandle;
+    private final List< SourceAndConverter > sourceAndConverters;
+
+    private Interval initialInterval;
+    private Interval rangeInterval;
+
+    public BdvBoundingBoxDialog( BdvHandle bdvHandle, List< SourceAndConverter > sourceAndConverters)
+    {
+        this.bdvHandle = bdvHandle;
+        this.sourceAndConverters = sourceAndConverters;
+    }
+
+    public void showRealBoxAndWaitForResult()
+    {
+        setInitialSelectionAndRange( );
+
+        final TransformedRealBoxSelectionDialog.Result result = showRealBox( );
+
+        if ( result.isValid() )
+        {
+            final RealInterval interval = result.getInterval();
+            final int minTimepoint = result.getMinTimepoint();
+            final int maxTimepoint = result.getMaxTimepoint();
+        }
+    }
+
+    private TransformedRealBoxSelectionDialog.Result showRealBox( )
+    {
+        final AffineTransform3D boxTransform = new AffineTransform3D();
+
+        return BdvFunctions.selectRealBox(
+                bdvHandle,
+                boxTransform,
+                initialInterval,
+                rangeInterval,
+                BoxSelectionOptions.options()
+                        .title( "Crop" )
+                        .initialTimepointRange( 0, 0 )
+                        .selectTimepointRange( 0, 0 )
+        );
+    }
+
+    private void setInitialSelectionAndRange( )
+    {
+        final FinalRealInterval viewerBoundingInterval = getViewerGlobalBoundingInterval( bdvHandle );
+
+        double[] initialCenter = new double[ 3 ];
+        double[] initialSize = new double[ 3 ];
+
+        for (int d = 0; d < 2; d++)
+        {
+            initialCenter[ d ] = ( viewerBoundingInterval.realMax( d ) + viewerBoundingInterval.realMin( d ) ) / 2.0;
+            initialSize[ d ] = ( viewerBoundingInterval.realMax( d ) - viewerBoundingInterval.realMin( d ) );
+        }
+
+        initialSize[ 3 ] = 10.0;
+
+        double[] minInitial = new double[ 3 ];
+        double[] maxInitial = new double[ 3 ];
+        double[] minRange = new double[ 3 ];
+        double[] maxRange = new double[ 3 ];
+
+        for ( int d = 0; d < 3; d++ )
+        {
+            minInitial[  d ] = initialCenter[ d ] - initialSize[ d ] / 4;
+            maxInitial[  d ] = initialCenter[ d ] + initialSize[ d ] / 4;
+            minRange[  d ] = initialCenter[ d ] - initialSize[ d ] / 2;
+            maxRange[  d ] = initialCenter[ d ] + initialSize[ d ] / 2;
+        }
+
+        initialInterval = Intervals.createMinMax(
+                (long) minInitial[0], (long) minInitial[1], (long) minInitial[2],
+                (long) maxInitial[0], (long) maxInitial[1], (long) maxInitial[2]);
+
+        rangeInterval = Intervals.createMinMax(
+                (long) minRange[0], (long) minRange[1], (long) minRange[2],
+                (long) maxRange[0], (long) maxRange[1], (long) maxRange[2]);
+    }
+
+    private static FinalRealInterval getViewerGlobalBoundingInterval( Bdv bdv )
+    {
+        AffineTransform3D viewerTransform = new AffineTransform3D();
+        bdv.getBdvHandle().getViewerPanel().state().getViewerTransform( viewerTransform );
+        viewerTransform = viewerTransform.inverse();
+        final long[] min = new long[ 3 ];
+        final long[] max = new long[ 3 ];
+        max[ 0 ] = bdv.getBdvHandle().getViewerPanel().getWidth();
+        max[ 1 ] = bdv.getBdvHandle().getViewerPanel().getHeight();
+        final FinalRealInterval realInterval
+                = viewerTransform.estimateBounds( new FinalInterval( min, max ) );
+        return realInterval;
+    }
+}

--- a/src/main/java/org/embl/mobie/viewer/bdv/BdvBoundingBoxDialog.java
+++ b/src/main/java/org/embl/mobie/viewer/bdv/BdvBoundingBoxDialog.java
@@ -54,6 +54,9 @@ public class BdvBoundingBoxDialog
 
     private Interval initialInterval;
     private Interval rangeInterval;
+    private RealInterval interval;
+    private int minTimepoint;
+    private int maxTimepoint;
 
     public BdvBoundingBoxDialog( BdvHandle bdvHandle, List< SourceAndConverter > sourceAndConverters)
     {
@@ -69,10 +72,25 @@ public class BdvBoundingBoxDialog
 
         if ( result.isValid() )
         {
-            final RealInterval interval = result.getInterval();
-            final int minTimepoint = result.getMinTimepoint();
-            final int maxTimepoint = result.getMaxTimepoint();
+            interval = result.getInterval();
+            minTimepoint = result.getMinTimepoint();
+            maxTimepoint = result.getMaxTimepoint();
         }
+    }
+
+    public RealInterval getInterval()
+    {
+        return interval;
+    }
+
+    public int getMinTimepoint()
+    {
+        return minTimepoint;
+    }
+
+    public int getMaxTimepoint()
+    {
+        return maxTimepoint;
     }
 
     private TransformedRealBoxSelectionDialog.Result showRealBox( )
@@ -98,13 +116,13 @@ public class BdvBoundingBoxDialog
         double[] initialCenter = new double[ 3 ];
         double[] initialSize = new double[ 3 ];
 
-        for (int d = 0; d < 2; d++)
+        for (int d = 0; d < 3; d++)
         {
             initialCenter[ d ] = ( viewerBoundingInterval.realMax( d ) + viewerBoundingInterval.realMin( d ) ) / 2.0;
             initialSize[ d ] = ( viewerBoundingInterval.realMax( d ) - viewerBoundingInterval.realMin( d ) );
         }
 
-        initialSize[ 3 ] = 10.0;
+        initialSize[ 2 ] = 10.0;
 
         double[] minInitial = new double[ 3 ];
         double[] maxInitial = new double[ 3 ];

--- a/src/main/java/org/embl/mobie/viewer/bdv/view/SliceViewer.java
+++ b/src/main/java/org/embl/mobie/viewer/bdv/view/SliceViewer.java
@@ -6,6 +6,7 @@ import org.embl.mobie.viewer.bdv.MobieBdvSupplier;
 import org.embl.mobie.viewer.bdv.MobieSerializableBdvOptions;
 import org.embl.mobie.viewer.bdv.SourcesAtMousePositionSupplier;
 import org.embl.mobie.viewer.bdv.ViewerTransformLogger;
+import org.embl.mobie.viewer.command.CroppedViewCommand;
 import org.embl.mobie.viewer.command.ImagePlusExportCommand;
 import org.embl.mobie.viewer.command.ManualRegistrationCommand;
 import org.embl.mobie.viewer.command.BigWarpRegistrationCommand;
@@ -106,6 +107,7 @@ public class SliceViewer implements Supplier< BdvHandle >
 		actions.add( sacService.getCommandName( ScreenShotMakerCommand.class ) );
 		actions.add( sacService.getCommandName( ImagePlusExportCommand.class ) );
 		actions.add( sacService.getCommandName( ViewerTransformLogger.class ) );
+		actions.add( sacService.getCommandName( CroppedViewCommand.class ) );
 		actions.add( sacService.getCommandName( BigWarpRegistrationCommand.class ) );
 		actions.add( sacService.getCommandName( ManualRegistrationCommand.class ) );
 		actions.add( sacService.getCommandName( SourceAndConverterBlendingModeChangerCommand.class ) );

--- a/src/main/java/org/embl/mobie/viewer/command/CroppedViewCommand.java
+++ b/src/main/java/org/embl/mobie/viewer/command/CroppedViewCommand.java
@@ -1,0 +1,56 @@
+package org.embl.mobie.viewer.command;
+
+import bdv.tools.transformation.TransformedSource;
+import bdv.util.BdvHandle;
+import bdv.viewer.SourceAndConverter;
+import net.imagej.patcher.LegacyInjector;
+import net.imglib2.realtransform.AffineTransform3D;
+import org.embl.mobie.viewer.bdv.BdvBoundingBoxDialog;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+import sc.fiji.bdvpg.scijava.command.BdvPlaygroundActionCommand;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Plugin(type = BdvPlaygroundActionCommand.class, menuPath = CommandConstants.CONTEXT_MENU_ITEMS_ROOT + CroppedViewCommand.NAME )
+public class CroppedViewCommand implements BdvPlaygroundActionCommand
+{
+	static{ LegacyInjector.preinit(); }
+
+	public static final String NAME = "Create cropped view";
+
+	@Parameter( label = "Bdv" )
+	BdvHandle bdvHandle;
+
+	@Parameter( label = "Source(s)" )
+	public SourceAndConverter[] sourceAndConverterArray;
+
+	@Override
+	public void run()
+	{
+
+		final List< SourceAndConverter > sourceAndConverters = Arrays.stream( sourceAndConverterArray ).collect( Collectors.toList() );
+		if ( sourceAndConverters.size() == 0 ) return;
+
+		new Thread( () -> {
+			final BdvBoundingBoxDialog boxDialog = new BdvBoundingBoxDialog( bdvHandle, sourceAndConverters );
+			boxDialog.showRealBoxAndWaitForResult();
+		}).start();
+
+	}
+
+	private HashMap< SourceAndConverter< ? >, AffineTransform3D > fetchTransforms( List< SourceAndConverter< ? > > sourceAndConverters )
+	{
+		final HashMap< SourceAndConverter< ? >, AffineTransform3D > sacToTransform = new HashMap<>();
+		for ( SourceAndConverter movingSac : sourceAndConverters )
+		{
+			final AffineTransform3D fixedTransform = new AffineTransform3D();
+			( ( TransformedSource ) movingSac.getSpimSource()).getFixedTransform( fixedTransform );
+			sacToTransform.put( movingSac, fixedTransform );
+		}
+		return sacToTransform;
+	}
+}

--- a/src/main/java/org/embl/mobie/viewer/command/CroppedViewCommand.java
+++ b/src/main/java/org/embl/mobie/viewer/command/CroppedViewCommand.java
@@ -7,9 +7,9 @@ import bdv.util.BdvHandle;
 import bdv.viewer.SourceAndConverter;
 import net.imagej.patcher.LegacyInjector;
 import net.imglib2.RealInterval;
-import net.imglib2.RealLocalizable;
 import net.imglib2.RealPoint;
 import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.util.Intervals;
 import org.embl.mobie.viewer.bdv.BdvBoundingBoxDialog;
 import org.embl.mobie.viewer.transform.MaskedSource;
 import org.scijava.plugin.Parameter;
@@ -50,14 +50,11 @@ public class CroppedViewCommand implements BdvPlaygroundActionCommand
 			final AffineTransform3D maskTransform = new AffineTransform3D();
 			result.getTransform( maskTransform );
 
-			final boolean test = result.asMask().test( new RealPoint( new double[]{ 0, 0, 0 } ) );
-			final boolean test2 = result.asMask().test( new RealPoint( new double[]{ 130, 130, 140 } ) );
-
 			for ( SourceAndConverter sourceAndConverter : sourceAndConverters )
 			{
-				final MaskedSource maskedSource = new MaskedSource<>( sourceAndConverter.getSpimSource(), sourceAndConverter.getSpimSource().getName() + "-crop", maskInterval, maskTransform, false );
+				final MaskedSource maskedSource = new MaskedSource<>( sourceAndConverter.getSpimSource(), sourceAndConverter.getSpimSource().getName() + "-crop", maskInterval.minAsDoubleArray(), maskInterval.maxAsDoubleArray(), maskTransform, false );
 
-				final MaskedSource volatileMaskedSource = new MaskedSource<>( sourceAndConverter.asVolatile().getSpimSource(), sourceAndConverter.getSpimSource().getName() + "-crop", maskInterval, maskTransform, false );
+				final MaskedSource volatileMaskedSource = new MaskedSource<>( sourceAndConverter.asVolatile().getSpimSource(), sourceAndConverter.getSpimSource().getName() + "-crop", maskInterval.minAsDoubleArray(), maskInterval.maxAsDoubleArray(), maskTransform, false  );
 
 				final SourceAndConverter croppedSourceAndConverter = new SourceAndConverter( maskedSource, SourceAndConverterHelper.cloneConverter( sourceAndConverter.getConverter(), sourceAndConverter ), new SourceAndConverter( volatileMaskedSource, SourceAndConverterHelper.cloneConverter( sourceAndConverter.asVolatile().getConverter(), sourceAndConverter.asVolatile() ) ) );
 

--- a/src/main/java/org/embl/mobie/viewer/command/ImagePlusExportCommand.java
+++ b/src/main/java/org/embl/mobie/viewer/command/ImagePlusExportCommand.java
@@ -177,15 +177,4 @@ public class ImagePlusExportCommand< T extends NumericType< T > > implements Bdv
 		return Views.stack( rais );
 	}
 
-	private HashMap< SourceAndConverter< T >, AffineTransform3D > fetchTransforms( List< SourceAndConverter< T > > movingSacs )
-	{
-		final HashMap< SourceAndConverter< T >, AffineTransform3D > sacToTransform = new HashMap<>();
-		for ( SourceAndConverter movingSac : movingSacs )
-		{
-			final AffineTransform3D fixedTransform = new AffineTransform3D();
-			( ( TransformedSource ) movingSac.getSpimSource()).getFixedTransform( fixedTransform );
-			sacToTransform.put( movingSac, fixedTransform );
-		}
-		return sacToTransform;
-	}
 }

--- a/src/main/java/org/embl/mobie/viewer/transform/CropSourceTransformer.java
+++ b/src/main/java/org/embl/mobie/viewer/transform/CropSourceTransformer.java
@@ -1,11 +1,8 @@
 package org.embl.mobie.viewer.transform;
 
 import bdv.viewer.SourceAndConverter;
-import mpicbg.spim.data.sequence.FinalVoxelDimensions;
-import mpicbg.spim.data.sequence.VoxelDimensions;
 import net.imglib2.FinalRealInterval;
-import sc.fiji.bdvpg.sourceandconverter.importer.EmptySourceAndConverterCreator;
-import sc.fiji.bdvpg.sourceandconverter.transform.SourceResampler;
+import net.imglib2.RealInterval;
 
 import java.util.List;
 import java.util.Map;
@@ -28,20 +25,7 @@ public class CropSourceTransformer extends AbstractSourceTransformer
 				final SourceAndConverter< ? > sourceAndConverter = sourceNameToSourceAndConverter.get( sourceName );
 				String transformedSourceName = getTransformedSourceName( sourceName );
 
-				// determine number of voxels for resampling
-				// the current method may over-sample quite a bit
-				final double smallestVoxelSize = getSmallestVoxelSize( sourceAndConverter );
-				final FinalVoxelDimensions croppedSourceVoxelDimensions = new FinalVoxelDimensions( sourceAndConverter.getSpimSource().getVoxelDimensions().unit(), smallestVoxelSize, smallestVoxelSize, smallestVoxelSize );
-				int[] numVoxels = getNumVoxels( smallestVoxelSize );
-				SourceAndConverter< ? > cropModel = new EmptySourceAndConverterCreator("Model", new FinalRealInterval( min, max ), numVoxels[ 0 ], numVoxels[ 1 ], numVoxels[ 2 ], croppedSourceVoxelDimensions ).get();
-
-				// resample generative source as model source
-				SourceAndConverter< ? > croppedSourceAndConverter = new SourceResampler( sourceAndConverter, cropModel, transformedSourceName, false,false, false,0).get();
-
-				if ( centerAtOrigin )
-				{
-					croppedSourceAndConverter = TransformHelper.centerAtOrigin( croppedSourceAndConverter );
-				}
+				SourceAndConverter< ? > croppedSourceAndConverter = SourceCropper.crop( sourceAndConverter, transformedSourceName, new FinalRealInterval( min, max ), centerAtOrigin );
 
 				// store result
 				sourceNameToSourceAndConverter.put( croppedSourceAndConverter.getSpimSource().getName(), croppedSourceAndConverter );
@@ -56,28 +40,14 @@ public class CropSourceTransformer extends AbstractSourceTransformer
 	}
 
 
-	private int[] getNumVoxels( double smallestVoxelSize )
+	public static int[] getNumVoxels( double smallestVoxelSize, RealInterval interval )
 	{
 		int[] numVoxels = new int[ 3 ];
 		for ( int d = 0; d < 3; d++ )
 		{
-			numVoxels[ d ] = (int) Math.ceil( ( max[ d ] - min[ d ] ) / smallestVoxelSize );
+			numVoxels[ d ] = (int) Math.ceil( ( interval.realMax( d ) - interval.realMin( d ) ) / smallestVoxelSize );
 		}
 		return numVoxels;
-	}
-
-	public static double getSmallestVoxelSize( SourceAndConverter< ? > sourceAndConverter )
-	{
-		final VoxelDimensions voxelDimensions = sourceAndConverter.getSpimSource().getVoxelDimensions();
-		double smallestVoxelSize = Double.MAX_VALUE;
-		for ( int d = 0; d < 3; d++ )
-		{
-			if ( voxelDimensions.dimension( d ) < smallestVoxelSize )
-			{
-				smallestVoxelSize = voxelDimensions.dimension( d );
-			}
-		}
-		return smallestVoxelSize;
 	}
 
 	private String getTransformedSourceName( String inputSourceName )

--- a/src/main/java/org/embl/mobie/viewer/transform/CroppedSource.java
+++ b/src/main/java/org/embl/mobie/viewer/transform/CroppedSource.java
@@ -33,14 +33,11 @@ import bdv.viewer.Interpolation;
 import bdv.viewer.Source;
 import mpicbg.spim.data.sequence.VoxelDimensions;
 import net.imglib2.FinalInterval;
-import net.imglib2.FinalRealInterval;
 import net.imglib2.Interval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.RealInterval;
 import net.imglib2.RealRandomAccessible;
 import net.imglib2.realtransform.AffineTransform3D;
-import net.imglib2.realtransform.InverseRealTransform;
-import net.imglib2.realtransform.RealTransformRandomAccessible;
 import net.imglib2.realtransform.RealViews;
 import net.imglib2.type.numeric.NumericType;
 import net.imglib2.util.Intervals;
@@ -49,30 +46,31 @@ import net.imglib2.view.IntervalView;
 import net.imglib2.view.Views;
 
 import java.util.HashMap;
-import java.util.function.Function;
 
 public class CroppedSource< T extends NumericType<T> > implements Source< T > //, Function< Source< T >, Source< T > >
 {
     private Source< T > source;
     private final String name;
-    private final RealInterval crop;
+    private final RealInterval realInterval;
     private final boolean zeroMin;
 
     protected transient final DefaultInterpolators< T > interpolators;
     private transient HashMap< Integer, Interval > levelToVoxelInterval;
 
-    public CroppedSource( Source< T > source, String name, RealInterval crop, boolean zeroMin )
+    // TODO: add affine transform to orient the crop
+    public CroppedSource( Source< T > source, String name, RealInterval realInterval, boolean zeroMin )
     {
         this.source = source;
         this.name = name;
-        this.crop = crop;
+        this.realInterval = realInterval;
         this.zeroMin = zeroMin;
         this.interpolators = new DefaultInterpolators();
 
-        initCropIntervals( source, crop );
+        initVoxelCropIntervals( source, realInterval );
     }
 
-    private void initCropIntervals( Source< T > source, RealInterval crop )
+    // TODO: this only makes sense if the crop is specified in the corrdinate system of the RAI, which typically would not be the case :(
+    private void initVoxelCropIntervals( Source< T > source, RealInterval crop )
     {
         final AffineTransform3D transform3D = new AffineTransform3D();
         levelToVoxelInterval = new HashMap<>();

--- a/src/main/java/org/embl/mobie/viewer/transform/MaskedSource.java
+++ b/src/main/java/org/embl/mobie/viewer/transform/MaskedSource.java
@@ -31,59 +31,47 @@ package org.embl.mobie.viewer.transform;
 import bdv.util.DefaultInterpolators;
 import bdv.viewer.Interpolation;
 import bdv.viewer.Source;
-import de.embl.cba.tables.plot.RealPointARGBTypeBiConsumerSupplier;
-import mpicbg.models.PointMatch;
 import mpicbg.spim.data.sequence.VoxelDimensions;
 import net.imglib2.FinalInterval;
 import net.imglib2.Interval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.RealInterval;
-import net.imglib2.RealLocalizable;
 import net.imglib2.RealPoint;
 import net.imglib2.RealRandomAccessible;
-import net.imglib2.converter.Converter;
-import net.imglib2.converter.Converters;
 import net.imglib2.position.FunctionRealRandomAccessible;
 import net.imglib2.realtransform.AffineTransform3D;
-import net.imglib2.realtransform.RealViews;
-import net.imglib2.roi.RealMask;
 import net.imglib2.roi.RealMaskRealInterval;
-import net.imglib2.roi.geom.GeomMasks;
-import net.imglib2.type.numeric.ARGBType;
 import net.imglib2.type.numeric.NumericType;
 import net.imglib2.util.Intervals;
 import net.imglib2.util.Util;
 import net.imglib2.view.ExtendedRandomAccessibleInterval;
-import net.imglib2.view.IntervalView;
 import net.imglib2.view.Views;
 
 import java.util.HashMap;
-import java.util.function.BiConsumer;
-import java.util.function.Supplier;
 
-public class CroppedSource< T extends NumericType<T> > implements Source< T > //, Function< Source< T >, Source< T > >
+public class MaskedSource< T extends NumericType<T> > implements Source< T > //, Function< Source< T >, Source< T > >
 {
     private Source< T > source;
     private final String name;
-    private final RealInterval realCrop;
-    private final boolean zeroMin;
+    private final RealMaskRealInterval mask;
+    private final boolean center;
 
     protected transient final DefaultInterpolators< T > interpolators;
     private transient HashMap< Integer, Interval > levelToVoxelInterval;
 
     // TODO: add affine transform to orient the crop
-    public CroppedSource( Source< T > source, String name, RealInterval realCrop, boolean zeroMin )
+    public MaskedSource( Source< T > source, String name, RealMaskRealInterval mask, boolean center )
     {
         this.source = source;
         this.name = name;
-        this.realCrop = realCrop;
-        this.zeroMin = zeroMin;
+        this.mask = mask;
+        this.center = center;
         this.interpolators = new DefaultInterpolators();
 
-        initVoxelCropIntervals( source, realCrop );
+        // TODO Do we need this? It could be nice for the bounding box culling
+        initVoxelCropIntervals( source, mask );
     }
 
-    // TODO: this only makes sense if the crop is specified in the corrdinate system of the RAI, which typically would not be the case :(
     private void initVoxelCropIntervals( Source< T > source, RealInterval crop )
     {
         final AffineTransform3D transform3D = new AffineTransform3D();
@@ -125,47 +113,44 @@ public class CroppedSource< T extends NumericType<T> > implements Source< T > //
     @Override
     public RandomAccessibleInterval< T > getSource(int t, int level)
     {
-        final RandomAccessibleInterval< T > rai = source.getSource( t, level );
-        final IntervalView< T > croppedRai = Views.interval( rai, levelToVoxelInterval.get( level ) );
-
-        if ( zeroMin )
-            return Views.zeroMin( croppedRai );
-        else
-            return croppedRai;
+        return source.getSource( t, level );
     }
 
     @Override
     public RealRandomAccessible< T > getInterpolatedSource( int t, int level, Interpolation method )
     {
         final RandomAccessibleInterval< T > rai = getSource( t, level );
-        ExtendedRandomAccessibleInterval<T, RandomAccessibleInterval< T >>
-                extendedRai = Views.extendZero( rai );
+        ExtendedRandomAccessibleInterval<T, RandomAccessibleInterval< T >> extendedRai = Views.extendZero( rai );
         RealRandomAccessible< T > rra = Views.interpolate( extendedRai, interpolators.get(method) );
 
-        // Note that the rra is not yet in the coordinate space of this source,
-        // which is defined by source.getSourceTransform( t, level, affineTransform3D );
-
+        // sourceTransform: data space (of rra) to physical space
         final AffineTransform3D sourceTransform = new AffineTransform3D();
         source.getSourceTransform( t, level, sourceTransform );
 
-        final T type = rai.randomAccess().get();
+        final T type = Util.getTypeFromInterval( rai );
 
-        final FunctionRealRandomAccessible< T > realRandomAccessible = new FunctionRealRandomAccessible< T >( 3,
-                ( p, value ) -> {
-                    final RealPoint globalCoordinates = new RealPoint( 3 );
-                    sourceTransform.applyInverse( globalCoordinates, p );
-                    final boolean contains = Intervals.contains( realCrop, globalCoordinates );
-                    if ( contains )
-                    {
-                        value.set( rra.getAt( p ) );
-                    }
+        final FunctionRealRandomAccessible< T > realRandomAccessible = new FunctionRealRandomAccessible< T >(
+                3,
+                ( dataCoordinates, value ) -> {
+
+                    final RealPoint physicalCoordinates = new RealPoint( 3 );
+                    sourceTransform.apply( dataCoordinates, physicalCoordinates );
+
+                    if ( mask.test( physicalCoordinates ) )
+                        value.set( rra.getAt( dataCoordinates ) );
                     else
-                    {
                         value.setZero();
-                    }
-                }, () -> type.copy() );
+
+                },
+                () -> type.createVariable() );
 
         return realRandomAccessible;
+    }
+
+    @Override
+    public boolean doBoundingBoxCulling()
+    {
+        return true;
     }
 
     @Override

--- a/src/main/java/org/embl/mobie/viewer/transform/MaskedSource.java
+++ b/src/main/java/org/embl/mobie/viewer/transform/MaskedSource.java
@@ -56,7 +56,8 @@ public class MaskedSource< T extends NumericType<T> > implements Source< T >, So
     // TODO serialise
     private Source< T > source;
     private final String name;
-    private final RealInterval maskInterval; // maybe double min and max?
+    private final double[] maskMin;
+    private final double[] maskMax;
     private final AffineTransform3D maskTransform;
     private final boolean center;
 
@@ -64,21 +65,23 @@ public class MaskedSource< T extends NumericType<T> > implements Source< T >, So
     private transient HashMap< Integer, Interval > levelToVoxelInterval;
     private transient RealMaskRealInterval mask;
 
-    public MaskedSource( Source< T > source, String name, RealInterval maskInterval, AffineTransform3D maskTransform, boolean center )
+    public MaskedSource( Source< T > source, String name, double[] maskMin, double[] maskMax, AffineTransform3D maskTransform, boolean center  )
     {
         this.source = source;
         this.name = name;
-        this.maskInterval = maskInterval;
+        this.maskMin = maskMin;
+        this.maskMax = maskMax;
         this.maskTransform = maskTransform;
         this.center = center;
 
         this.interpolators = new DefaultInterpolators();
-        this.mask = GeomMasks.closedBox( Intervals.minAsDoubleArray( maskInterval ), Intervals.maxAsDoubleArray( maskInterval ) ).transform( maskTransform.inverse() );
+        this.mask = GeomMasks.closedBox( maskMin, maskMax ).transform( maskTransform.inverse() );
 
         // TODO Do we need this? It could be nice for the bounding box culling
-        initVoxelCropIntervals( source, maskInterval );
+       // initVoxelCropIntervals( source, maskInterval );
     }
 
+    // TODO: remove or keep?
     private void initVoxelCropIntervals( Source< T > source, RealInterval crop )
     {
         final AffineTransform3D transform3D = new AffineTransform3D();

--- a/src/main/java/org/embl/mobie/viewer/transform/SourceCropper.java
+++ b/src/main/java/org/embl/mobie/viewer/transform/SourceCropper.java
@@ -1,0 +1,43 @@
+package org.embl.mobie.viewer.transform;
+
+import bdv.viewer.SourceAndConverter;
+import mpicbg.spim.data.sequence.FinalVoxelDimensions;
+import mpicbg.spim.data.sequence.VoxelDimensions;
+import net.imglib2.RealInterval;
+import sc.fiji.bdvpg.sourceandconverter.importer.EmptySourceAndConverterCreator;
+import sc.fiji.bdvpg.sourceandconverter.transform.SourceResampler;
+
+public class SourceCropper
+{
+	public static SourceAndConverter< ? > crop( SourceAndConverter< ? > sourceAndConverter, String transformedSourceName, RealInterval interval, boolean centerAtOrigin )
+	{
+		// determine number of voxels for resampling
+		// TODO the current method may over-sample quite a bit
+		final double smallestVoxelSize = getSmallestVoxelSize( sourceAndConverter );
+		final FinalVoxelDimensions croppedSourceVoxelDimensions = new FinalVoxelDimensions( sourceAndConverter.getSpimSource().getVoxelDimensions().unit(), smallestVoxelSize, smallestVoxelSize, smallestVoxelSize );
+		int[] numVoxels = CropSourceTransformer.getNumVoxels( smallestVoxelSize, interval );
+		SourceAndConverter< ? > cropModel = new EmptySourceAndConverterCreator("Model", interval, numVoxels[ 0 ], numVoxels[ 1 ], numVoxels[ 2 ], croppedSourceVoxelDimensions ).get();
+
+		// resample generative source as model source
+		SourceAndConverter< ? > croppedSourceAndConverter = new SourceResampler( sourceAndConverter, cropModel, transformedSourceName, false,false, false,0).get();
+
+		if ( centerAtOrigin )
+			croppedSourceAndConverter = TransformHelper.centerAtOrigin( croppedSourceAndConverter );
+
+		return croppedSourceAndConverter;
+	}
+
+	public static double getSmallestVoxelSize( SourceAndConverter< ? > sourceAndConverter )
+	{
+		final VoxelDimensions voxelDimensions = sourceAndConverter.getSpimSource().getVoxelDimensions();
+		double smallestVoxelSize = Double.MAX_VALUE;
+		for ( int d = 0; d < 3; d++ )
+		{
+			if ( voxelDimensions.dimension( d ) < smallestVoxelSize )
+			{
+				smallestVoxelSize = voxelDimensions.dimension( d );
+			}
+		}
+		return smallestVoxelSize;
+	}
+}

--- a/src/test/java/projects/OpenRemoteCOMULIS.java
+++ b/src/test/java/projects/OpenRemoteCOMULIS.java
@@ -13,6 +13,6 @@ public class OpenRemoteCOMULIS
 	{
 		final ImageJ imageJ = new ImageJ();
 		imageJ.ui().showUI();
-		new MoBIE("https://s3.embl.de/comulis", MoBIESettings.settings().imageDataFormat( ImageDataFormat.BdvOmeZarrS3 ).s3AccessAndSecretKey( new String[]{"abc","def"} ) );
+		new MoBIE("https://s3.embl.de/comulis", MoBIESettings.settings().imageDataFormat( ImageDataFormat.BdvOmeZarrS3 ).s3AccessAndSecretKey( new String[]{"UYP3FNN3V5F0P86DR2O3","3EL7Czzg0vVwx2L4v27GQiX0Ct1GkMHS+tbcJR3D "} ) );
 	}
 }


### PR DESCRIPTION
Made great progress in enabling interactive cropping in MoBIE, even when the viewer is not aligned with the physical axes 🥳  

<img width="800" alt="image" src="https://user-images.githubusercontent.com/2157566/154806308-823da3ed-d944-492d-99a6-c731edcd33e2.png">


Also seems I found a much better way to implement the crop as a `MaskedSource` (thanks to great help in https://gitter.im/imglib/imglib2)

- [ ] implement the `center` feature, which is not yet done in the `MaskedSource` 
- [ ] check whether we could entirely replace the current `CropSourceTransformer` and make it it use the new `MaskedSource`, which seems to be much more performant and also easier to understand.
- [ ] implement https://github.com/mobie/mobie-viewer-fiji/issues/606


@martinschorb Could you please point me to a simple example where we use the crop of a source?