### PR TITLE
Enforce a particular unit for the project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
 	<groupId>org.embl.mobie</groupId>
 	<artifactId>mobie-viewer-fiji</artifactId>
-	<version>2.1.0</version>
+	<version>2.1.5</version>
 
 	<!-- mvn clean install -Dscijava.app.directory=/Users/tischer/Desktop/Fiji/Fiji-MoBIE-beta.app -->
 	<!-- mvn clean install -Dscijava.app.directory=/Users/tischer/Desktop/Fiji/Fiji-MoBIE.app -->

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
 		<!-- EMBL CBA -->
 		<imagej-utils.version>0.6.4</imagej-utils.version>
 
-		<mobie-io.version>1.2.2</mobie-io.version>
+		<mobie-io.version>1.2.5</mobie-io.version>
 
 		<!-- Version 1.6.0-scijava-3-SNAPSHOT of j3dcore addresses a minor issue
 		https://github.com/fiji/3D_Viewer/issues/26

--- a/src/main/java/org/embl/mobie/viewer/projectcreator/ImagesCreator.java
+++ b/src/main/java/org/embl/mobie/viewer/projectcreator/ImagesCreator.java
@@ -156,9 +156,13 @@ public class ImagesCreator {
         String filePath = getDefaultLocalImagePath( datasetName, imageName, imageDataFormat );
         File imageFile = new File(filePath);
 
-        if ( imp.getNChannels() > 1 ) {
-            throw new UnsupportedOperationException("Multi-channel images are not supported.\n" +
-                    "Please add each channel individually ([ Image > Color > Split Channels ]).\n" );
+        if ( !isImageValid( imp.getNChannels(), imp.getCalibration().getUnit(),
+                projectCreator.getVoxelUnit(), false ) ) {
+            return;
+        }
+
+        if ( projectCreator.getVoxelUnit() == null ) {
+            projectCreator.setVoxelUnit( imp.getCalibration().getUnit() );
         }
 
         if ( imageFile.exists() ) {
@@ -310,6 +314,17 @@ public class ImagesCreator {
 
             SpimData spimData = ( SpimData ) new SpimDataOpener().openSpimData( fileLocation.getAbsolutePath(), imageDataFormat );
             File imageDirectory = new File( getDefaultLocalImageDirPath( datasetName, imageDataFormat ));
+
+            int nChannels = spimData.getSequenceDescription().getViewSetupsOrdered().size();
+            String imageUnit = spimData.getSequenceDescription().getViewSetupsOrdered().get(0).getVoxelSize().unit();
+
+            if ( !isImageValid( nChannels, imageUnit, projectCreator.getVoxelUnit(), true ) ) {
+                return;
+            }
+
+            if ( projectCreator.getVoxelUnit() == null ) {
+                projectCreator.setVoxelUnit( imageUnit );
+            }
 
             File newImageFile = null;
             switch( imageDataFormat ) {

--- a/src/main/java/org/embl/mobie/viewer/projectcreator/ProjectCreator.java
+++ b/src/main/java/org/embl/mobie/viewer/projectcreator/ProjectCreator.java
@@ -139,6 +139,10 @@ public class ProjectCreator {
         return voxelUnit;
     }
 
+    public void setVoxelUnit(String voxelUnit) {
+        this.voxelUnit = voxelUnit;
+    }
+
     public void reloadCurrentDataset() throws IOException {
         if ( currentDatasetName != null ) {
             this.currentDataset = new DatasetJsonParser().parseDataset(currentDatasetJson.getAbsolutePath());

--- a/src/main/java/org/embl/mobie/viewer/projectcreator/ProjectCreator.java
+++ b/src/main/java/org/embl/mobie/viewer/projectcreator/ProjectCreator.java
@@ -1,10 +1,17 @@
 package org.embl.mobie.viewer.projectcreator;
 
+import mpicbg.spim.data.SpimData;
+import mpicbg.spim.data.SpimDataException;
+import mpicbg.spim.data.sequence.VoxelDimensions;
+import org.embl.mobie.io.ImageDataFormat;
+import org.embl.mobie.io.SpimDataOpener;
 import org.embl.mobie.viewer.Dataset;
 import org.embl.mobie.viewer.Project;
 import org.embl.mobie.viewer.serialize.DatasetJsonParser;
 import org.embl.mobie.viewer.serialize.ProjectJsonParser;
 import org.embl.mobie.io.util.FileAndUrlUtils;
+import org.embl.mobie.viewer.source.ImageSource;
+import org.embl.mobie.viewer.source.SourceSupplier;
 
 import java.io.File;
 import java.io.IOException;
@@ -24,6 +31,7 @@ public class ProjectCreator {
     private String currentDatasetName;
     private Dataset currentDataset;
     private Map<String, ArrayList<String> > currentGrouptoViews;
+    private String voxelUnit;
 
     private final DatasetsCreator datasetsCreator;
     private final ImagesCreator imagesCreator;
@@ -60,6 +68,12 @@ public class ProjectCreator {
         this.projectJsonCreator = new ProjectJsonCreator( this );
         this.imagesCreator = new ImagesCreator( this );
         this.remoteMetadataCreator = new RemoteMetadataCreator( this );
+
+        try {
+            readVoxelUnitFromImage();
+        } catch (SpimDataException e) {
+            e.printStackTrace();
+        }
     }
 
     public File getDataLocation() { return dataLocation; }
@@ -121,6 +135,10 @@ public class ProjectCreator {
         return views;
     }
 
+    public String getVoxelUnit() {
+        return voxelUnit;
+    }
+
     public void reloadCurrentDataset() throws IOException {
         if ( currentDatasetName != null ) {
             this.currentDataset = new DatasetJsonParser().parseDataset(currentDatasetJson.getAbsolutePath());
@@ -144,5 +162,33 @@ public class ProjectCreator {
 
     public RemoteMetadataCreator getRemoteMetadataCreator() {
         return remoteMetadataCreator;
+    }
+
+    private void readVoxelUnitFromImage() throws SpimDataException {
+        // open first image (if any exist) to determine voxel unit
+        if ( project.getDatasets().size() == 0 ) {
+            return;
+        }
+
+        for ( String datasetName: project.getDatasets() ) {
+            Dataset dataset = getDataset( datasetName );
+            if ( dataset != null && dataset.sources.size() > 0 ) {
+                for ( SourceSupplier sourceSupplier: dataset.sources.values() ) {
+                    ImageSource imageSource = sourceSupplier.get();
+                    // open one of the local images
+                    for (ImageDataFormat format : imageSource.imageData.keySet()) {
+                        if (!format.isRemote()) {
+                            String imagePath = FileAndUrlUtils.combinePath( dataLocation.getAbsolutePath(), datasetName,
+                                    imageSource.imageData.get(format).relativePath);
+                            SpimData spimData = (SpimData) new SpimDataOpener().openSpimData( imagePath, format );
+                            VoxelDimensions voxelDimensions = spimData.getSequenceDescription().
+                                    getViewSetupsOrdered().get(0).getVoxelSize();
+                            voxelUnit = voxelDimensions.unit();
+                            return;
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/main/java/org/embl/mobie/viewer/projectcreator/ProjectCreatorHelper.java
+++ b/src/main/java/org/embl/mobie/viewer/projectcreator/ProjectCreatorHelper.java
@@ -3,9 +3,7 @@ package org.embl.mobie.viewer.projectcreator;
 import bdv.img.n5.N5ImageLoader;
 import org.embl.mobie.io.ImageDataFormat;
 import org.embl.mobie.io.n5.loaders.N5FSImageLoader;
-import org.embl.mobie.io.n5.loaders.N5S3ImageLoader;
 import org.embl.mobie.io.ome.zarr.loaders.N5OMEZarrImageLoader;
-import org.embl.mobie.io.ome.zarr.loaders.N5S3OMEZarrImageLoader;
 import org.embl.mobie.io.ome.zarr.readers.N5OmeZarrReader;
 import org.embl.mobie.viewer.Dataset;
 import org.embl.mobie.viewer.view.View;
@@ -18,9 +16,8 @@ import mpicbg.spim.data.SpimData;
 import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
 import mpicbg.spim.data.generic.sequence.BasicImgLoader;
 import mpicbg.spim.data.generic.sequence.BasicViewSetup;
-import mpicbg.spim.data.sequence.FinalVoxelDimensions;
-import net.imglib2.FinalDimensions;
 import net.imglib2.realtransform.AffineTransform3D;
+import ucar.units.*;
 
 import java.io.File;
 import java.text.DecimalFormat;
@@ -34,27 +31,6 @@ import static org.embl.mobie.viewer.ui.UserInterfaceHelper.tidyString;
 public class ProjectCreatorHelper {
 
     static { net.imagej.patcher.LegacyInjector.preinit(); }
-
-    public static boolean isImageSuitable(ImagePlus imp) {
-        // check the image type
-        switch (imp.getType()) {
-            case ImagePlus.GRAY8:
-            case ImagePlus.GRAY16:
-            case ImagePlus.GRAY32:
-                break;
-            default:
-                IJ.showMessage("Only 8, 16, 32-bit images are supported currently!");
-                return false;
-        }
-
-        // check the image dimensionality
-        if (imp.getNDimensions() < 2) {
-            IJ.showMessage("Image must be at least 2-dimensional!");
-            return false;
-        }
-
-        return true;
-    }
 
     public static boolean isValidAffine(String affine) {
         if (!affine.matches("^[0-9., ]+$")) {
@@ -97,69 +73,6 @@ public class ProjectCreatorHelper {
         defaultAffine.scale( pixelWidth, pixelHeight, pixelDepth );
 
         return defaultAffine;
-    }
-
-    public static FinalVoxelDimensions getVoxelSize(ImagePlus imp) {
-        final double pw = imp.getCalibration().pixelWidth;
-        final double ph = imp.getCalibration().pixelHeight;
-        final double pd = imp.getCalibration().pixelDepth;
-        String punit = imp.getCalibration().getUnit();
-        if (punit == null || punit.isEmpty())
-            punit = "px";
-        final FinalVoxelDimensions voxelSize = new FinalVoxelDimensions(punit, pw, ph, pd);
-        return voxelSize;
-    }
-
-    public static FinalDimensions getSize(ImagePlus imp) {
-        final int w = imp.getWidth();
-        final int h = imp.getHeight();
-        final int d = imp.getNSlices();
-        final FinalDimensions size = new FinalDimensions(w, h, d);
-        return size;
-    }
-
-    public static File getSeqFileFromPath(String seqFilename) {
-        final File seqFile = new File(seqFilename);
-        final File parent = seqFile.getParentFile();
-        if (parent == null || !parent.exists() || !parent.isDirectory()) {
-            IJ.showMessage("Invalid export filename " + seqFilename);
-            return null;
-        }
-        return seqFile;
-    }
-
-    public static AffineTransform3D generateSourceTransform(FinalVoxelDimensions voxelSize) {
-        // create SourceTransform from the images calibration
-        final AffineTransform3D sourceTransform = new AffineTransform3D();
-        sourceTransform.set(voxelSize.dimension(0), 0, 0, 0, 0, voxelSize.dimension(1),
-                0, 0, 0, 0, voxelSize.dimension(2), 0);
-        return sourceTransform;
-    }
-
-    public static File getN5FileFromXmlPath(String xmlPath) {
-        final String n5Filename = xmlPath.substring(0, xmlPath.length() - 4) + ".n5";
-        return new File(n5Filename);
-    }
-
-    public static File getOmeZarrFileFromXmlPath(String xmlPath) {
-        final String omeZarrFileName = xmlPath.substring(0, xmlPath.length() - 4) + ".ome.zarr";
-        return new File(omeZarrFileName);
-    }
-
-    public static ImageDataFormat getImageFormatFromSpimDataMinimal( SpimData spimData ) {
-        ImageDataFormat imageFormat = null;
-        BasicImgLoader imgLoader = spimData.getSequenceDescription().getImgLoader();
-        if ( imgLoader instanceof N5FSImageLoader | imgLoader instanceof N5ImageLoader ) {
-            imageFormat = ImageDataFormat.BdvN5;
-        } else if ( imgLoader instanceof N5S3ImageLoader ) {
-            imageFormat = ImageDataFormat.BdvN5S3;
-        } else if ( imgLoader instanceof N5OMEZarrImageLoader ) {
-            imageFormat = ImageDataFormat.OmeZarr;
-        } else if ( imgLoader instanceof N5S3OMEZarrImageLoader ) {
-            imageFormat = ImageDataFormat.OmeZarrS3;
-        }
-
-        return imageFormat;
     }
 
     public static File getImageLocationFromSequenceDescription( AbstractSequenceDescription seq, ImageDataFormat imageFormat ) {
@@ -293,4 +206,53 @@ public class ProjectCreatorHelper {
 
         return voxelString;
     }
+
+    private static String replaceMu( String string ) {
+        // Convert the mu symbol into "u" - as udunits can't handle this
+        return  string.replace("\u00B5", "u");
+    }
+
+    public static boolean unitsEqual( String unit1, String unit2 ) throws PrefixDBException, UnitSystemException, SpecificationException, UnitDBException {
+        // check with udunits that units are equivalent
+        UnitFormat unitFormatter = UnitFormatManager.instance();
+        Unit parsedUnit1 = unitFormatter.parse(replaceMu(unit1));
+        Unit parsedUnit2 = unitFormatter.parse(replaceMu(unit2));
+
+        return parsedUnit1.getCanonicalString().equals(parsedUnit2.getCanonicalString());
+    }
+
+    public static boolean isImageValid( int nChannels, String imageUnit, String projectUnit, boolean bdvFormat ) {
+        // reject multi-channel images
+        if ( nChannels > 1 ) {
+            // for bdv format images, don't print the fiji shortcuts
+            String channelMessage = "Multi-channel images are not supported. \n Please split the channels";
+            if ( !bdvFormat ) {
+                IJ.log( channelMessage + " [ Image > Color > Split Channels], and add each separately.");
+            } else {
+                IJ.log(channelMessage + ", and add each separately.");
+            }
+            return false;
+        }
+
+        // reject images with a different unit to the rest of the project
+        try {
+            if ( projectUnit != null && !unitsEqual( imageUnit, projectUnit) ) {
+                String unitMessage = "Image has a different unit (" + imageUnit + ") to the rest of the project (" +
+                        projectUnit + "). \n Please set your image unit";
+                if (! bdvFormat ) {
+                    IJ.log( unitMessage + " under [ Image > Properties... ] to match the project.");
+                } else {
+                    IJ.log( unitMessage + " to match the project." );
+                }
+                return false;
+            }
+        } catch (PrefixDBException | UnitSystemException | SpecificationException | UnitDBException e) {
+            IJ.log("Couldn't parse unit.");
+            e.printStackTrace();
+            return false;
+        }
+
+        return true;
+    }
+
 }

--- a/src/main/java/org/embl/mobie/viewer/projectcreator/ui/ProjectsCreatorPanel.java
+++ b/src/main/java/org/embl/mobie/viewer/projectcreator/ui/ProjectsCreatorPanel.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.embl.mobie.viewer.projectcreator.ProjectCreatorHelper.getVoxelSizeString;
+import static org.embl.mobie.viewer.projectcreator.ProjectCreatorHelper.*;
 
 public class ProjectsCreatorPanel extends JFrame {
 
@@ -49,9 +49,9 @@ public class ProjectsCreatorPanel extends JFrame {
     private static boolean exclusive = false;
     private static boolean useFileNameAsImageName = true;
 
-    private String[] imageFormats = new String[]{ ImageDataFormat.BdvN5.toString(),
+    private final String[] imageFormats = new String[]{ ImageDataFormat.BdvN5.toString(),
             ImageDataFormat.OmeZarr.toString() };
-    private String[] imageTypes = new String[]{ ProjectCreator.ImageType.image.toString(),
+    private final String[] imageTypes = new String[]{ ProjectCreator.ImageType.image.toString(),
             ProjectCreator.ImageType.segmentation.toString() };
 
 
@@ -465,9 +465,8 @@ public class ProjectsCreatorPanel extends JFrame {
         if ( !datasetName.equals("") ) {
             ImagePlus currentImage = IJ.getImage();
 
-            if ( currentImage.getNChannels() > 1 ) {
-                IJ.log("Image " + currentImage.getTitle() + " has multiple channels. \n Please split " +
-                        "the channels [ Image > Color > Split Channels], and add each separately." );
+            if ( !isImageValid( currentImage.getNChannels(), currentImage.getCalibration().getUnit(),
+                    projectsCreator.getVoxelUnit(), false ) ) {
                 return;
             }
 

--- a/src/main/java/org/embl/mobie/viewer/projectcreator/ui/ProjectsCreatorPanel.java
+++ b/src/main/java/org/embl/mobie/viewer/projectcreator/ui/ProjectsCreatorPanel.java
@@ -48,6 +48,7 @@ public class ProjectsCreatorPanel extends JFrame {
     private static boolean useDefaultExportSettings = true;
     private static boolean exclusive = false;
     private static boolean useFileNameAsImageName = true;
+    private static String uiSelectionGroup = "Make New Ui Selection Group";
 
     private final String[] imageFormats = new String[]{ ImageDataFormat.BdvN5.toString(),
             ImageDataFormat.OmeZarr.toString() };
@@ -407,7 +408,7 @@ public class ProjectsCreatorPanel extends JFrame {
             for (int i = 0; i < currentSelectionGroups.length; i++) {
                 choices[i + 1] = currentSelectionGroups[i];
             }
-            gd.addChoice("Ui Selection Group", choices, choices[0]);
+            gd.addChoice("Ui Selection Group", choices, uiSelectionGroup);
             gd.showDialog();
 
             if ( !gd.wasCanceled() ) {
@@ -514,10 +515,11 @@ public class ProjectsCreatorPanel extends JFrame {
                         return;
                     }
 
-                    String uiSelectionGroup = null;
-                    uiSelectionGroup = selectUiSelectionGroupDialog(datasetName);
-                    if ( uiSelectionGroup == null ) {
+                    String chosenUiSelectionGroup = selectUiSelectionGroupDialog(datasetName);
+                    if ( chosenUiSelectionGroup == null ) {
                         return;
+                    } else {
+                        uiSelectionGroup = chosenUiSelectionGroup;
                     }
 
                     try {
@@ -619,10 +621,11 @@ public class ProjectsCreatorPanel extends JFrame {
                         return;
                     }
 
-                    String uiSelectionGroup = null;
-                    uiSelectionGroup = selectUiSelectionGroupDialog(datasetName);
-                    if ( uiSelectionGroup == null ) {
+                    String chosenUiSelectionGroup = selectUiSelectionGroupDialog(datasetName);
+                    if ( chosenUiSelectionGroup == null ) {
                         return;
+                    } else {
+                        uiSelectionGroup = chosenUiSelectionGroup;
                     }
 
                     try {


### PR DESCRIPTION
Fixes https://github.com/mobie/mobie-viewer-fiji/issues/583 and https://github.com/mobie/mobie-viewer-fiji/issues/611

Main changes:
- Enforces a project voxel unit (determined by the first image added)
- All images added after are checked against this (using udunits, so it can handle e.g. microns, um, micrometer etc being the same thing). Any images with units that don't match are rejected, and can't be added.
- makes project creator remember the last selected uiSelectionGroup

Requires this PR first: https://github.com/mobie/mobie-io/pull/84