### PR TITLE
Allow selection of 2D/3D when dataset is created

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
 	<groupId>org.embl.mobie</groupId>
 	<artifactId>mobie-viewer-fiji</artifactId>
-	<version>2.1.5</version>
+	<version>2.1.6</version>
 
 	<!-- mvn clean install -Dscijava.app.directory=/Users/tischer/Desktop/Fiji/Fiji-MoBIE-beta.app -->
 	<!-- mvn clean install -Dscijava.app.directory=/Users/tischer/Desktop/Fiji/Fiji-MoBIE.app -->

--- a/src/main/java/org/embl/mobie/viewer/projectcreator/DatasetJsonCreator.java
+++ b/src/main/java/org/embl/mobie/viewer/projectcreator/DatasetJsonCreator.java
@@ -32,11 +32,19 @@ public class DatasetJsonCreator {
         this.projectCreator = projectCreator;
     }
 
-    public void addImageToDatasetJson( String imageName, String datasetName,
-                                      String uiSelectionGroup, boolean is2D, int nTimepoints,
-                                      ImageDataFormat imageDataFormat, double[] contrastLimits, String colour,
-                                      boolean exclusive, AffineTransform3D sourceTransform ) {
-        Dataset dataset = fetchDataset( datasetName, is2D, nTimepoints );
+    public void addDataset( String datasetName, boolean is2D ) {
+        Dataset dataset = new Dataset();
+        dataset.sources = new HashMap<>();
+        dataset.views = new HashMap<>();
+        dataset.is2D = is2D;
+        writeDatasetJson( datasetName, dataset );
+    }
+
+    public void addImage(String imageName, String datasetName,
+                         String uiSelectionGroup, int nTimepoints,
+                         ImageDataFormat imageDataFormat, double[] contrastLimits, String colour,
+                         boolean exclusive, AffineTransform3D sourceTransform ) {
+        Dataset dataset = fetchDataset( datasetName, nTimepoints );
 
         addNewImageSource( dataset, imageName, imageDataFormat );
         if ( uiSelectionGroup != null ) {
@@ -53,10 +61,10 @@ public class DatasetJsonCreator {
         projectCreator.getProjectJsonCreator().addImageDataFormat( imageDataFormat );
     }
 
-    public void addSegmentationToDatasetJson( String imageName, String datasetName, String uiSelectionGroup,
-                                              boolean is2D, int nTimepoints, ImageDataFormat imageDataFormat,
-                                              boolean exclusive, AffineTransform3D sourceTransform ) {
-        Dataset dataset = fetchDataset( datasetName, is2D, nTimepoints );
+    public void addSegmentation(String imageName, String datasetName, String uiSelectionGroup,
+                                int nTimepoints, ImageDataFormat imageDataFormat,
+                                boolean exclusive, AffineTransform3D sourceTransform ) {
+        Dataset dataset = fetchDataset( datasetName, nTimepoints );
 
         addNewSegmentationSource( dataset, imageName, imageDataFormat );
         if ( uiSelectionGroup != null ) {
@@ -73,19 +81,14 @@ public class DatasetJsonCreator {
         projectCreator.getProjectJsonCreator().addImageDataFormat( imageDataFormat );
     }
 
-    private Dataset fetchDataset( String datasetName, boolean is2D, int nTimepoints ) {
+    public void makeDataset2D( String datasetName, boolean is2D ) {
         Dataset dataset = projectCreator.getDataset( datasetName );
-        if ( dataset == null ) {
-            dataset = new Dataset();
-            dataset.sources = new HashMap<>();
-            dataset.views = new HashMap<>();
-            // start new datasets with is2D as true, then for the first 3D image added it can be set to false
-            dataset.is2D = true;
-        }
+        dataset.is2D = is2D;
+        writeDatasetJson( datasetName, dataset );
+    }
 
-        if ( !is2D ) {
-            dataset.is2D = false;
-        }
+    private Dataset fetchDataset( String datasetName, int nTimepoints ) {
+        Dataset dataset = projectCreator.getDataset( datasetName );
 
         if ( nTimepoints > dataset.timepoints ) {
             dataset.timepoints = nTimepoints;

--- a/src/main/java/org/embl/mobie/viewer/projectcreator/DatasetsCreator.java
+++ b/src/main/java/org/embl/mobie/viewer/projectcreator/DatasetsCreator.java
@@ -23,6 +23,7 @@ public class DatasetsCreator {
     /**
      * Create a new, empty dataset
      * @param datasetName dataset name
+     * @param is2D whether dataset only contains 2D images
      */
     public void addDataset ( String datasetName, boolean is2D ) {
         List<String> currentDatasets = projectCreator.getProject().getDatasets();

--- a/src/main/java/org/embl/mobie/viewer/projectcreator/DatasetsCreator.java
+++ b/src/main/java/org/embl/mobie/viewer/projectcreator/DatasetsCreator.java
@@ -24,7 +24,7 @@ public class DatasetsCreator {
      * Create a new, empty dataset
      * @param datasetName dataset name
      */
-    public void addDataset ( String datasetName ) {
+    public void addDataset ( String datasetName, boolean is2D ) {
         List<String> currentDatasets = projectCreator.getProject().getDatasets();
         boolean contains = currentDatasets.contains(datasetName);
         if ( !contains ) {
@@ -42,6 +42,9 @@ public class DatasetsCreator {
 
                 // update project json
                 projectCreator.getProjectJsonCreator().addDataset( datasetName );
+
+                // create dataset json
+                projectCreator.getDatasetJsonCreator().addDataset( datasetName, is2D );
             } else {
                 IJ.log( "Dataset creation failed - this name already exists" );
             }
@@ -90,6 +93,16 @@ public class DatasetsCreator {
      */
     public void makeDefaultDataset ( String datasetName ) {
         projectCreator.getProjectJsonCreator().setDefaultDataset( datasetName );
+    }
+
+
+    /**
+     * Make a dataset 2D or 3D
+     * @param datasetName dataset name
+     * @param is2D 2D or not
+     */
+    public void makeDataset2D( String datasetName, boolean is2D ) {
+        projectCreator.getDatasetJsonCreator().makeDataset2D( datasetName, is2D );
     }
 
 }

--- a/src/main/java/org/embl/mobie/viewer/projectcreator/ImagesCreator.java
+++ b/src/main/java/org/embl/mobie/viewer/projectcreator/ImagesCreator.java
@@ -38,6 +38,7 @@ import mpicbg.spim.data.sequence.SequenceDescription;
 
 import javax.swing.*;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -188,6 +189,10 @@ public class ImagesCreator {
             return;
         }
 
+        if ( imp.getNDimensions() > 2 && projectCreator.getDataset( datasetName ).is2D ) {
+            throw new UnsupportedOperationException("Can't add a " + imp.getNDimensions() + "D image to a 2D dataset" );
+        }
+
         if ( projectCreator.getVoxelUnit() == null ) {
             projectCreator.setVoxelUnit( imp.getCalibration().getUnit() );
         }
@@ -213,21 +218,15 @@ public class ImagesCreator {
 
         // check image written successfully, before writing jsons
         if ( imageFile.exists() ) {
-            boolean is2D;
-            if ( imp.getNDimensions() <= 2 ) {
-                is2D = true;
-            } else {
-                is2D = false;
-            }
             if (imageType == ProjectCreator.ImageType.image) {
                 double[] contrastLimits = new double[]{imp.getDisplayRangeMin(), imp.getDisplayRangeMax()};
                 LUT lut = imp.getLuts()[0];
                 String colour = "r=" + lut.getRed(255) + ",g=" + lut.getGreen(255) + ",b=" +
                         lut.getBlue(255) + ",a=" + lut.getAlpha(255);
-                updateTableAndJsonsForNewImage( imageName, datasetName, uiSelectionGroup, is2D,
+                updateTableAndJsonsForNewImage( imageName, datasetName, uiSelectionGroup,
                         imp.getNFrames(), imageDataFormat, contrastLimits, colour, exclusive, sourceTransform );
             } else {
-                updateTableAndJsonsForNewSegmentation(imageName, datasetName, uiSelectionGroup, is2D,
+                updateTableAndJsonsForNewSegmentation(imageName, datasetName, uiSelectionGroup,
                         imp.getNFrames(), imageDataFormat, exclusive, sourceTransform );
             }
         }
@@ -356,73 +355,101 @@ public class ImagesCreator {
                                     String uiSelectionGroup, ImageDataFormat imageDataFormat, boolean exclusive ) throws SpimDataException, IOException {
 
         if ( fileLocation.exists() ) {
-
             SpimData spimData = ( SpimData ) new SpimDataOpener().openSpimData( fileLocation.getAbsolutePath(), imageDataFormat );
-            File imageDirectory = new File( getDefaultLocalImageDirPath( datasetName, imageDataFormat ));
-
-            int nChannels = spimData.getSequenceDescription().getViewSetupsOrdered().size();
-            String imageUnit = spimData.getSequenceDescription().getViewSetupsOrdered().get(0).getVoxelSize().unit();
-
-            if ( !isImageValid( nChannels, imageUnit, projectCreator.getVoxelUnit(), true ) ) {
-                return;
-            }
-
-            if ( projectCreator.getVoxelUnit() == null ) {
-                projectCreator.setVoxelUnit( imageUnit );
-            }
-
-            File newImageFile = null;
-            switch( imageDataFormat ) {
-                case BdvN5:
-                    newImageFile = new File(imageDirectory, imageName + ".xml");
-                    // The view setup name must be the same as the image name
-                    spimData = fixSetupName( spimData, imageName );
-                    break;
-
-                case OmeZarr:
-                    newImageFile = new File(imageDirectory, imageName + ".ome.zarr" );
-                    break;
-            }
-
-            if ( newImageFile.exists() ) {
-                IJ.log("Overwriting image " + imageName + " in dataset " + datasetName );
-                deleteImageFiles( datasetName, imageName, imageDataFormat );
-            }
-
-            // make directory for that image file format, if doesn't exist already
-            File imageDir = new File( newImageFile.getParent() );
-            if ( !imageDir.exists() ) {
-                imageDir.mkdirs();
-            }
-
-            switch (addMethod) {
-                case link:
-                    // TODO - linking currently not supported for ome-zarr
-                    spimData.setBasePath( imageDir );
-                    new XmlIoSpimData().save(spimData, newImageFile.getAbsolutePath());
-                    break;
-                case copy:
-                    copyImage( imageDataFormat, spimData, imageDirectory, imageName);
-                    break;
-                case move:
-                    moveImage( imageDataFormat, spimData, imageDirectory, imageName);
-                    break;
-            }
-
-            if (imageType == ProjectCreator.ImageType.image) {
-                updateTableAndJsonsForNewImage( imageName, datasetName, uiSelectionGroup,
-                        isSpimData2D(spimData), getNTimepointsFromSpimData(spimData),
-                        imageDataFormat, new double[]{0.0, 255.0}, "white", exclusive, new AffineTransform3D() );
-            } else {
-                updateTableAndJsonsForNewSegmentation( imageName, datasetName, uiSelectionGroup,
-                        isSpimData2D(spimData), getNTimepointsFromSpimData(spimData), imageDataFormat, exclusive,
-                        new AffineTransform3D() );
-            }
-
-            IJ.log( "Bdv format image " + imageName + " added to project" );
+            addBdvFormatImage( spimData, imageName, datasetName, imageType, addMethod, uiSelectionGroup,
+                    imageDataFormat, exclusive );
         } else {
-            IJ.log( "Adding image to project failed - " + fileLocation.getAbsolutePath() + " does not exist" );
+            throw new FileNotFoundException(
+                    "Adding image to project failed - " + fileLocation.getAbsolutePath() + " does not exist" );
         }
+    }
+
+    /**
+     * Add a bdv format image to a MoBIE project (e.g. N5 or OME-ZARR). Make sure the scale and unit is set properly
+     * in the file. Note that multi-channel images are not supported - you will need to split these channels and add
+     * each as its own image.
+     * @param spimData spimData of n5 or ome-zarr file
+     * @param imageName image name
+     * @param datasetName dataset name
+     * @param imageType Image or Segmentation - segmentations will additionally generate a table.
+     * @param addMethod Add method - link (leave image as-is, and link to this location. Only supported for
+     *                  N5 and local projects), copy (copy image into project), or move (move image into project -
+     *                  be careful as this will delete the image from its original location!)
+     * @param uiSelectionGroup Name of MoBIE drop-down menu to place view in
+     * @param imageDataFormat image format
+     * @param exclusive Whether to make the view exclusive.
+     * @throws SpimDataException
+     * @throws IOException
+     */
+    public void addBdvFormatImage ( SpimData spimData, String imageName, String datasetName,
+                                    ProjectCreator.ImageType imageType, ProjectCreator.AddMethod addMethod,
+                                    String uiSelectionGroup, ImageDataFormat imageDataFormat, boolean exclusive ) throws SpimDataException, IOException {
+
+        File imageDirectory = new File( getDefaultLocalImageDirPath( datasetName, imageDataFormat ));
+
+        int nChannels = spimData.getSequenceDescription().getViewSetupsOrdered().size();
+        String imageUnit = spimData.getSequenceDescription().getViewSetupsOrdered().get(0).getVoxelSize().unit();
+
+        if ( !isImageValid( nChannels, imageUnit, projectCreator.getVoxelUnit(), true ) ) {
+            return;
+        }
+
+        if ( !isSpimData2D(spimData) && projectCreator.getDataset( datasetName ).is2D ) {
+            throw new UnsupportedOperationException("Can't add a 3D image to a 2D dataset" );
+        }
+
+        if ( projectCreator.getVoxelUnit() == null ) {
+            projectCreator.setVoxelUnit( imageUnit );
+        }
+
+        File newImageFile = null;
+        switch( imageDataFormat ) {
+            case BdvN5:
+                newImageFile = new File(imageDirectory, imageName + ".xml");
+                // The view setup name must be the same as the image name
+                spimData = fixSetupName( spimData, imageName );
+                break;
+
+            case OmeZarr:
+                newImageFile = new File(imageDirectory, imageName + ".ome.zarr" );
+                break;
+        }
+
+        if ( newImageFile.exists() ) {
+            IJ.log("Overwriting image " + imageName + " in dataset " + datasetName );
+            deleteImageFiles( datasetName, imageName, imageDataFormat );
+        }
+
+        // make directory for that image file format, if doesn't exist already
+        File imageDir = new File( newImageFile.getParent() );
+        if ( !imageDir.exists() ) {
+            imageDir.mkdirs();
+        }
+
+        switch (addMethod) {
+            case link:
+                // TODO - linking currently not supported for ome-zarr
+                spimData.setBasePath( imageDir );
+                new XmlIoSpimData().save(spimData, newImageFile.getAbsolutePath());
+                break;
+            case copy:
+                copyImage( imageDataFormat, spimData, imageDirectory, imageName);
+                break;
+            case move:
+                moveImage( imageDataFormat, spimData, imageDirectory, imageName);
+                break;
+        }
+
+        if (imageType == ProjectCreator.ImageType.image) {
+            updateTableAndJsonsForNewImage( imageName, datasetName, uiSelectionGroup,
+                    getNTimepointsFromSpimData(spimData), imageDataFormat, new double[]{0.0, 255.0},
+                    "white", exclusive, new AffineTransform3D() );
+        } else {
+            updateTableAndJsonsForNewSegmentation( imageName, datasetName, uiSelectionGroup,
+                    getNTimepointsFromSpimData(spimData), imageDataFormat, exclusive, new AffineTransform3D() );
+        }
+
+        IJ.log( "Bdv format image " + imageName + " added to project" );
     }
 
     private ArrayList<Object[]> makeDefaultTableRowsForTimepoint( Source labelsSource, int timepoint, boolean addTimepointColumn ) {
@@ -541,20 +568,20 @@ public class ImagesCreator {
     }
 
     private void updateTableAndJsonsForNewImage ( String imageName, String datasetName, String uiSelectionGroup,
-                                                  boolean is2D, int nTimepoints, ImageDataFormat imageDataFormat,
+                                                  int nTimepoints, ImageDataFormat imageDataFormat,
                                                   double[] contrastLimits, String colour,
                                                   boolean exclusive, AffineTransform3D sourceTransform ) {
         DatasetJsonCreator datasetJsonCreator = projectCreator.getDatasetJsonCreator();
-        datasetJsonCreator.addImageToDatasetJson( imageName, datasetName, uiSelectionGroup, is2D, nTimepoints,
+        datasetJsonCreator.addImage( imageName, datasetName, uiSelectionGroup, nTimepoints,
                 imageDataFormat, contrastLimits, colour, exclusive, sourceTransform );
     }
 
     private void updateTableAndJsonsForNewSegmentation( String imageName, String datasetName, String uiSelectionGroup,
-                                                        boolean is2D, int nTimepoints, ImageDataFormat imageDataFormat,
+                                                        int nTimepoints, ImageDataFormat imageDataFormat,
                                                         boolean exclusive, AffineTransform3D sourceTransform ) {
         addDefaultTableForImage( imageName, datasetName, imageDataFormat );
         DatasetJsonCreator datasetJsonCreator = projectCreator.getDatasetJsonCreator();
-        datasetJsonCreator.addSegmentationToDatasetJson( imageName, datasetName, uiSelectionGroup, is2D, nTimepoints,
+        datasetJsonCreator.addSegmentation( imageName, datasetName, uiSelectionGroup, nTimepoints,
                 imageDataFormat, exclusive, sourceTransform );
     }
 

--- a/src/main/java/org/embl/mobie/viewer/projectcreator/ui/ProjectsCreatorPanel.java
+++ b/src/main/java/org/embl/mobie/viewer/projectcreator/ui/ProjectsCreatorPanel.java
@@ -1,7 +1,9 @@
 package org.embl.mobie.viewer.projectcreator.ui;
 
+import mpicbg.spim.data.SpimData;
 import org.apache.commons.io.FilenameUtils;
 import org.embl.mobie.io.ImageDataFormat;
+import org.embl.mobie.io.SpimDataOpener;
 import org.embl.mobie.viewer.Dataset;
 import org.embl.mobie.viewer.MoBIE;
 import org.embl.mobie.viewer.Project;
@@ -49,6 +51,7 @@ public class ProjectsCreatorPanel extends JFrame {
     private static boolean exclusive = false;
     private static boolean useFileNameAsImageName = true;
     private static String uiSelectionGroup = "Make New Ui Selection Group";
+    private static boolean is2D = false;
 
     private final String[] imageFormats = new String[]{ ImageDataFormat.BdvN5.toString(),
             ImageDataFormat.OmeZarr.toString() };
@@ -446,6 +449,21 @@ public class ProjectsCreatorPanel extends JFrame {
         }
     }
 
+    private boolean changeDatasetDimensionDialog( String datasetName ) {
+        int result = JOptionPane.showConfirmDialog(null,
+                "This image is 3D, but the dataset (" + datasetName + ") is 2D. \n" +
+                        "Change the dataset to be 3D?", "Are you sure?",
+                JOptionPane.YES_NO_OPTION,
+                JOptionPane.QUESTION_MESSAGE);
+        if (result == JOptionPane.YES_OPTION) {
+            projectsCreator.getDatasetsCreator().makeDataset2D( datasetName, false );
+            return true;
+        } else {
+            IJ.log("Adding image aborted - can't add a 3D image to a 2D dataset" );
+            return false;
+        }
+    }
+
     private String imageNameDialog( File imageFile ) {
         final GenericDialog gd = new GenericDialog( "Choose image name..." );
         gd.addStringField( "Image Name", imageFile.getName().split("\\.")[0], 35 );
@@ -469,6 +487,12 @@ public class ProjectsCreatorPanel extends JFrame {
             if ( !isImageValid( currentImage.getNChannels(), currentImage.getCalibration().getUnit(),
                     projectsCreator.getVoxelUnit(), false ) ) {
                 return;
+            }
+
+            if ( currentImage.getNDimensions() > 2 && projectsCreator.getDataset( datasetName ).is2D ) {
+                if ( !changeDatasetDimensionDialog(datasetName) ) {
+                    return;
+                }
             }
 
             final GenericDialog gd = new GenericDialog( "Add Current Image To MoBIE Project..." );
@@ -602,37 +626,9 @@ public class ProjectsCreatorPanel extends JFrame {
                 }
 
                 if ( filePath != null ) {
-
-                    File imageFile = new File( filePath );
-                    String imageName = imageFile.getName().split("\\.")[0];
-                    if ( !useFileNameAsImageName ) {
-                        imageName = imageNameDialog( imageFile );
-                        if ( imageName == null ) {
-                            return;
-                        }
-                    }
-
-                    ImagesCreator imagesCreator = projectsCreator.getImagesCreator();
-                    boolean overwriteImage = true;
-                    if ( imagesCreator.imageExists( datasetName, imageName, imageDataFormat ) ) {
-                        overwriteImage = overwriteImageDialog();
-                    }
-                    if ( !overwriteImage ) {
-                        return;
-                    }
-
-                    String chosenUiSelectionGroup = selectUiSelectionGroupDialog(datasetName);
-                    if ( chosenUiSelectionGroup == null ) {
-                        return;
-                    } else {
-                        uiSelectionGroup = chosenUiSelectionGroup;
-                    }
-
                     try {
-                            imagesCreator.addBdvFormatImage(imageFile, imageName, datasetName, imageType,
-                                    addMethod, uiSelectionGroup, imageDataFormat, exclusive);
-                            updateComboBoxesForNewImage(imageName, uiSelectionGroup);
-                    } catch (SpimDataException | IOException e) {
+                        addBdvFile( filePath, datasetName );
+                    } catch (SpimDataException e) {
                         e.printStackTrace();
                     }
                 }
@@ -642,17 +638,69 @@ public class ProjectsCreatorPanel extends JFrame {
         }
     }
 
+    private void addBdvFile( String filePath, String datasetName ) throws SpimDataException {
+        SpimData spimData = ( SpimData ) new SpimDataOpener().openSpimData( filePath, imageDataFormat );
+
+        int nChannels = spimData.getSequenceDescription().getViewSetupsOrdered().size();
+        String imageUnit = spimData.getSequenceDescription().getViewSetupsOrdered().get(0).getVoxelSize().unit();
+
+        if ( !isImageValid( nChannels, imageUnit, projectsCreator.getVoxelUnit(), true ) ) {
+            return;
+        }
+
+        if ( !isSpimData2D(spimData) && projectsCreator.getDataset( datasetName ).is2D ) {
+            if ( !changeDatasetDimensionDialog(datasetName) ) {
+                return;
+            }
+        }
+
+        File imageFile = new File( filePath );
+        String imageName = imageFile.getName().split("\\.")[0];
+        if ( !useFileNameAsImageName ) {
+            imageName = imageNameDialog( imageFile );
+            if ( imageName == null ) {
+                return;
+            }
+        }
+
+        ImagesCreator imagesCreator = projectsCreator.getImagesCreator();
+        boolean overwriteImage = true;
+        if ( imagesCreator.imageExists( datasetName, imageName, imageDataFormat ) ) {
+            overwriteImage = overwriteImageDialog();
+        }
+        if ( !overwriteImage ) {
+            return;
+        }
+
+        String chosenUiSelectionGroup = selectUiSelectionGroupDialog(datasetName);
+        if ( chosenUiSelectionGroup == null ) {
+            return;
+        } else {
+            uiSelectionGroup = chosenUiSelectionGroup;
+        }
+
+        try {
+            imagesCreator.addBdvFormatImage(spimData, imageName, datasetName, imageType,
+                    addMethod, uiSelectionGroup, imageDataFormat, exclusive);
+            updateComboBoxesForNewImage(imageName, uiSelectionGroup);
+        } catch (SpimDataException | IOException e) {
+            e.printStackTrace();
+        }
+    }
+
     public void addDatasetDialog () {
         final GenericDialog gd = new GenericDialog( "Create a new dataset" );
         gd.addStringField( "Name of dataset", "", 35 );
+        gd.addCheckbox("2D only?", is2D );
         gd.showDialog();
 
         if ( !gd.wasCanceled() ) {
             String datasetName = gd.getNextString();
             datasetName = UserInterfaceHelpers.tidyString( datasetName );
+            is2D = gd.getNextBoolean();
 
             if ( datasetName != null ) {
-                projectsCreator.getDatasetsCreator().addDataset(datasetName);
+                projectsCreator.getDatasetsCreator().addDataset( datasetName, is2D );
                 updateDatasetsComboBox( datasetName );
             }
         }

--- a/src/main/java/org/embl/mobie/viewer/projectcreator/ui/ProjectsCreatorPanel.java
+++ b/src/main/java/org/embl/mobie/viewer/projectcreator/ui/ProjectsCreatorPanel.java
@@ -691,7 +691,7 @@ public class ProjectsCreatorPanel extends JFrame {
     public void addDatasetDialog () {
         final GenericDialog gd = new GenericDialog( "Create a new dataset" );
         gd.addStringField( "Name of dataset", "", 35 );
-        gd.addCheckbox("2D only?", is2D );
+        gd.addCheckbox("Limit images and display to only 2D?", is2D );
         gd.showDialog();
 
         if ( !gd.wasCanceled() ) {

--- a/src/test/java/org/embl/mobie/viewer/projectcreator/DatasetsCreatorTest.java
+++ b/src/test/java/org/embl/mobie/viewer/projectcreator/DatasetsCreatorTest.java
@@ -24,7 +24,7 @@ class DatasetsCreatorTest {
     @org.junit.jupiter.api.Test
     void addDataset() throws IOException {
         String datasetName = "test";
-        datasetsCreator.addDataset(datasetName);
+        datasetsCreator.addDataset(datasetName, false);
 
         Project project = new ProjectJsonParser().parseProject( projectCreator.getProjectJson().getAbsolutePath() );
         assertEquals(project.getDatasets().size(), 1);
@@ -36,7 +36,7 @@ class DatasetsCreatorTest {
     void renameDataset() throws IOException {
         String oldDatasetName = "test";
         String newDatasetName = "newName";
-        datasetsCreator.addDataset(oldDatasetName);
+        datasetsCreator.addDataset(oldDatasetName, false);
         datasetsCreator.renameDataset(oldDatasetName, newDatasetName);
 
         Project project = new ProjectJsonParser().parseProject( projectCreator.getProjectJson().getAbsolutePath() );
@@ -50,8 +50,8 @@ class DatasetsCreatorTest {
     void makeDefaultDataset() throws IOException {
         String dataset1Name = "dataset1";
         String dataset2Name = "dataset2";
-        datasetsCreator.addDataset(dataset1Name);
-        datasetsCreator.addDataset(dataset2Name);
+        datasetsCreator.addDataset(dataset1Name, false);
+        datasetsCreator.addDataset(dataset2Name, false);
 
         Project project;
         project = new ProjectJsonParser().parseProject( projectCreator.getProjectJson().getAbsolutePath() );

--- a/src/test/java/org/embl/mobie/viewer/projectcreator/DatasetsCreatorTest.java
+++ b/src/test/java/org/embl/mobie/viewer/projectcreator/DatasetsCreatorTest.java
@@ -1,8 +1,13 @@
 package org.embl.mobie.viewer.projectcreator;
 
+import de.embl.cba.tables.FileAndUrlUtils;
+import org.embl.mobie.viewer.Dataset;
 import org.embl.mobie.viewer.Project;
+import org.embl.mobie.viewer.serialize.DatasetJsonParser;
 import org.embl.mobie.viewer.serialize.ProjectJsonParser;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -15,13 +20,13 @@ class DatasetsCreatorTest {
     private ProjectCreator projectCreator;
     private DatasetsCreator datasetsCreator;
 
-    @org.junit.jupiter.api.BeforeEach
+    @BeforeEach
     void setUp( @TempDir Path tempDir ) throws IOException {
         projectCreator = new ProjectCreator( tempDir.toFile() );
         datasetsCreator = projectCreator.getDatasetsCreator();
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void addDataset() throws IOException {
         String datasetName = "test";
         datasetsCreator.addDataset(datasetName, false);
@@ -32,7 +37,7 @@ class DatasetsCreatorTest {
         assertTrue(new File(projectCreator.getDataLocation(), datasetName).exists());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void renameDataset() throws IOException {
         String oldDatasetName = "test";
         String newDatasetName = "newName";
@@ -46,7 +51,7 @@ class DatasetsCreatorTest {
         assertFalse(new File(projectCreator.getDataLocation(), oldDatasetName).exists());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void makeDefaultDataset() throws IOException {
         String dataset1Name = "dataset1";
         String dataset2Name = "dataset2";
@@ -61,5 +66,21 @@ class DatasetsCreatorTest {
 
         project = new ProjectJsonParser().parseProject( projectCreator.getProjectJson().getAbsolutePath() );
         assertEquals( project.getDefaultDataset(), dataset2Name );
+    }
+
+    @Test
+    void makeDataset2D() throws IOException {
+        String datasetName = "test";
+        String datasetJsonPath = FileAndUrlUtils.combinePath( projectCreator.getDataLocation().getAbsolutePath(),
+                datasetName, "dataset.json" );
+
+        Dataset dataset;
+        datasetsCreator.addDataset(datasetName, false);
+        dataset = new DatasetJsonParser().parseDataset( datasetJsonPath );
+        assertFalse( dataset.is2D );
+
+        datasetsCreator.makeDataset2D(datasetName, true);
+        dataset = new DatasetJsonParser().parseDataset( datasetJsonPath );
+        assertTrue( dataset.is2D );
     }
 }

--- a/src/test/java/org/embl/mobie/viewer/projectcreator/ImagesCreatorTest.java
+++ b/src/test/java/org/embl/mobie/viewer/projectcreator/ImagesCreatorTest.java
@@ -53,7 +53,7 @@ class ImagesCreatorTest {
         uiSelectionGroup = "testGroup";
         sourceTransform = new AffineTransform3D();
 
-        projectCreator.getDatasetsCreator().addDataset(datasetName);
+        projectCreator.getDatasetsCreator().addDataset(datasetName, false);
 
         datasetJsonPath = FileAndUrlUtils.combinePath( projectCreator.getDataLocation().getAbsolutePath(),
                 datasetName, "dataset.json" );

--- a/src/test/java/org/embl/mobie/viewer/projectcreator/ImagesCreatorTest.java
+++ b/src/test/java/org/embl/mobie/viewer/projectcreator/ImagesCreatorTest.java
@@ -97,7 +97,7 @@ class ImagesCreatorTest {
         assertTrue( dataset.sources.get(imageName).get().imageData.containsKey(imageDataFormat) );
     }
 
-    void assertionsForTableAdded( ImageDataFormat imageDataFormat ) throws IOException {
+    void assertionsForTableAdded( ) throws IOException {
         String tablePath = FileAndUrlUtils.combinePath( projectCreator.getDataLocation().getAbsolutePath(), datasetName, "tables", imageName, "default.tsv" );
         assertTrue( new File(tablePath).exists() );
 
@@ -106,9 +106,9 @@ class ImagesCreatorTest {
         assertTrue( segmentationSource.tableData.containsKey(TableDataFormat.TabDelimitedFile) );
     }
 
-    String writeImageAndGetPath( ImageDataFormat imageDataFormat ) {
+    String writeImageAndGetPath( ImageDataFormat imageDataFormat, boolean is2D ) {
         // save example image for testing adding bdv format images
-        ImagePlus imp = makeImage( imageName );
+        ImagePlus imp = makeImage( imageName, is2D );
         DownsampleBlock.DownsamplingMethod downsamplingMethod = DownsampleBlock.DownsamplingMethod.Average;
         Compression compression = new GzipCompression();
         String filePath;
@@ -135,15 +135,17 @@ class ImagesCreatorTest {
         return filePath;
     }
 
-    void testAddingImageInCertainFormat( ImageDataFormat imageDataFormat ) throws IOException, SpimDataException {
-
+    void addImageInCertainFormat( ImageDataFormat imageDataFormat, boolean is2D ) throws SpimDataException, IOException {
         // make an image with random values, same size as the imagej sample head image
-        ImagePlus imp = makeImage( imageName );
+        ImagePlus imp = makeImage( imageName, is2D );
 
         imagesCreator.addImage( imp, imageName, datasetName,
                 imageDataFormat, ProjectCreator.ImageType.image,
                 sourceTransform, uiSelectionGroup, false );
+    }
 
+    void testAddingImageInCertainFormat( ImageDataFormat imageDataFormat, boolean is2D ) throws IOException, SpimDataException {
+        addImageInCertainFormat( imageDataFormat, is2D );
         assertionsForImageAdded( imageDataFormat, false );
     }
 
@@ -155,13 +157,13 @@ class ImagesCreatorTest {
                 sourceTransform, uiSelectionGroup, false );
 
         assertionsForImageAdded( imageDataFormat, false );
-        assertionsForTableAdded( imageDataFormat );
+        assertionsForTableAdded();
     }
 
-    void testLinkingImagesInCertainFormat( ImageDataFormat imageDataFormat ) throws IOException, SpimDataException {
+    void testLinkingImagesInCertainFormat( ImageDataFormat imageDataFormat, boolean is2D ) throws IOException, SpimDataException {
 
         // save example image
-        String filePath = writeImageAndGetPath( imageDataFormat );
+        String filePath = writeImageAndGetPath( imageDataFormat, is2D );
 
         imagesCreator.addBdvFormatImage( new File(filePath), imageName, datasetName, ProjectCreator.ImageType.image,
                 ProjectCreator.AddMethod.link, uiSelectionGroup, imageDataFormat, false );
@@ -169,21 +171,23 @@ class ImagesCreatorTest {
         assertionsForImageAdded( imageDataFormat, true );
     }
 
-    void testCopyingImagesInCertainFormat( ImageDataFormat imageDataFormat ) throws IOException, SpimDataException {
-
+    void copyImageInCertainFormat( ImageDataFormat imageDataFormat, boolean is2D ) throws SpimDataException, IOException {
         // save example image
-        String filePath = writeImageAndGetPath( imageDataFormat );
+        String filePath = writeImageAndGetPath( imageDataFormat, is2D );
 
         imagesCreator.addBdvFormatImage( new File(filePath), imageName, datasetName, ProjectCreator.ImageType.image,
                 ProjectCreator.AddMethod.copy, uiSelectionGroup, imageDataFormat, false );
+    }
 
+    void testCopyingImagesInCertainFormat( ImageDataFormat imageDataFormat, boolean is2D ) throws IOException, SpimDataException {
+        copyImageInCertainFormat( imageDataFormat, is2D );
         assertionsForImageAdded( imageDataFormat, false );
     }
 
-    void testMovingImagesInCertainFormat( ImageDataFormat imageDataFormat ) throws IOException, SpimDataException {
+    void testMovingImagesInCertainFormat( ImageDataFormat imageDataFormat, boolean is2D ) throws IOException, SpimDataException {
 
         // save example image
-        String filePath = writeImageAndGetPath( imageDataFormat );
+        String filePath = writeImageAndGetPath( imageDataFormat, is2D );
 
         imagesCreator.addBdvFormatImage( new File(filePath), imageName, datasetName, ProjectCreator.ImageType.image,
                 ProjectCreator.AddMethod.move, uiSelectionGroup, imageDataFormat, false );
@@ -193,7 +197,7 @@ class ImagesCreatorTest {
 
     @Test
     void addImageBdvN5() throws IOException, SpimDataException {
-        testAddingImageInCertainFormat( ImageDataFormat.BdvN5 );
+        testAddingImageInCertainFormat( ImageDataFormat.BdvN5, false );
     }
 
     @Test
@@ -203,7 +207,7 @@ class ImagesCreatorTest {
 
     @Test
     void addImageOmeZarr() throws IOException, SpimDataException {
-        testAddingImageInCertainFormat( ImageDataFormat.OmeZarr );
+        testAddingImageInCertainFormat( ImageDataFormat.OmeZarr, false );
     }
 
     @Test
@@ -213,26 +217,52 @@ class ImagesCreatorTest {
 
     @Test
     void linkToImageBdvN5() throws IOException, SpimDataException {
-        testLinkingImagesInCertainFormat( ImageDataFormat.BdvN5 );
+        testLinkingImagesInCertainFormat( ImageDataFormat.BdvN5, false );
     }
 
     @Test
     void copyImageBdvN5() throws IOException, SpimDataException {
-        testCopyingImagesInCertainFormat( ImageDataFormat.BdvN5 );
+        testCopyingImagesInCertainFormat( ImageDataFormat.BdvN5, false );
     }
 
     @Test
     void copyImageOmeZarr() throws IOException, SpimDataException {
-        testCopyingImagesInCertainFormat( ImageDataFormat.OmeZarr );
+        testCopyingImagesInCertainFormat( ImageDataFormat.OmeZarr, false );
     }
 
     @Test
     void moveImageBdvN5() throws IOException, SpimDataException {
-        testMovingImagesInCertainFormat( ImageDataFormat.BdvN5 );
+        testMovingImagesInCertainFormat( ImageDataFormat.BdvN5, false );
     }
 
     @Test
     void moveImageOmeZarr() throws IOException, SpimDataException {
-        testMovingImagesInCertainFormat( ImageDataFormat.OmeZarr );
+        testMovingImagesInCertainFormat( ImageDataFormat.OmeZarr, false );
+    }
+
+    @Test
+    void add2DImageTo3DDataset() throws SpimDataException, IOException {
+        testAddingImageInCertainFormat( ImageDataFormat.BdvN5, true );
+    }
+
+    @Test
+    void copy2DImageTo3DDataset() throws SpimDataException, IOException {
+        testCopyingImagesInCertainFormat( ImageDataFormat.BdvN5, true );
+    }
+
+    @Test
+    void add3DImageTo2DDataset() {
+        projectCreator.getDatasetsCreator().makeDataset2D(datasetName, true);
+        assertThrows( UnsupportedOperationException.class, () -> {
+            addImageInCertainFormat( ImageDataFormat.BdvN5, false);
+        } );
+    }
+
+    @Test
+    void copy3DImageTo2DDataset() {
+        projectCreator.getDatasetsCreator().makeDataset2D(datasetName, true);
+        assertThrows( UnsupportedOperationException.class, () -> {
+            copyImageInCertainFormat( ImageDataFormat.BdvN5, false);
+        } );
     }
 }

--- a/src/test/java/org/embl/mobie/viewer/projectcreator/ProjectCreatorTestHelper.java
+++ b/src/test/java/org/embl/mobie/viewer/projectcreator/ProjectCreatorTestHelper.java
@@ -8,9 +8,13 @@ public class ProjectCreatorTestHelper {
 
     static { net.imagej.patcher.LegacyInjector.preinit(); }
 
-    public static ImagePlus makeImage( String imageName ) {
+    public static ImagePlus makeImage( String imageName, boolean is2D ) {
         // make an image with random values, same size as the imagej sample head image
-        return IJ.createImage(imageName, "8-bit noise", 186, 226, 27);
+        if ( !is2D ) {
+            return IJ.createImage(imageName, "8-bit noise", 186, 226, 27);
+        } else {
+            return IJ.createImage(imageName, "8-bit noise", 186, 226, 0);
+        }
     }
 
     public static ImagePlus makeSegmentation( String imageName ) {

--- a/src/test/java/org/embl/mobie/viewer/projectcreator/RemoteMetadataCreatorTest.java
+++ b/src/test/java/org/embl/mobie/viewer/projectcreator/RemoteMetadataCreatorTest.java
@@ -46,7 +46,7 @@ class RemoteMetadataCreatorTest {
     void testAddingRemoteMetadataForCertainFormat( ImageDataFormat imageDataFormat ) throws IOException, SpimDataException {
 
         // add image of right type
-        projectCreator.getImagesCreator().addImage( ProjectCreatorTestHelper.makeImage(imageName), imageName,
+        projectCreator.getImagesCreator().addImage( ProjectCreatorTestHelper.makeImage(imageName, false), imageName,
                 datasetName, imageDataFormat, ProjectCreator.ImageType.image, new AffineTransform3D(),
                 uiSelectionGroup, false );
 

--- a/src/test/java/org/embl/mobie/viewer/projectcreator/RemoteMetadataCreatorTest.java
+++ b/src/test/java/org/embl/mobie/viewer/projectcreator/RemoteMetadataCreatorTest.java
@@ -38,7 +38,7 @@ class RemoteMetadataCreatorTest {
         signingRegion = "us-west-2";
         serviceEndpoint = "https://s3.test.de/test/";
         bucketName = "test-bucket";
-        projectCreator.getDatasetsCreator().addDataset(datasetName);
+        projectCreator.getDatasetsCreator().addDataset(datasetName, false);
         datasetJsonPath = FileAndUrlUtils.combinePath( projectCreator.getDataLocation().getAbsolutePath(),
                 datasetName, "dataset.json" );
     }


### PR DESCRIPTION
fixes https://github.com/mobie/mobie-viewer-fiji/issues/623
Main changes:
- Dialog for creating dataset now has checkbox for 2D/3D
- When adding a 3D image to a 2D dataset, a dialog appears allowing you to change the dataset to 3D or abort
- adds tests for adding 2D images to 3D and 2D datasets
![Screenshot 2022-03-04 124336](https://user-images.githubusercontent.com/24316371/156766402-0a9f5826-07f0-49dc-9475-2cc6aa5a74bc.png)