### PR TITLE
S3 credentials

### DIFF
--- a/src/main/java/org/embl/mobie/viewer/projectcreator/RemoteMetadataCreator.java
+++ b/src/main/java/org/embl/mobie/viewer/projectcreator/RemoteMetadataCreator.java
@@ -169,6 +169,7 @@ public class RemoteMetadataCreator {
             StorageLocation storageLocation = new StorageLocation();
             String relativePath = imageSource.imageData.get(localImageDataFormat).relativePath;
             storageLocation.s3Address = serviceEndpoint + bucketName + "/" + datasetName + "/" + relativePath;
+            storageLocation.signingRegion = signingRegion;
             imageSource.imageData.put( remoteImageDataFormat, storageLocation );
         }
 
@@ -209,6 +210,10 @@ public class RemoteMetadataCreator {
         this.serviceEndpoint = serviceEndpoint;
         this.bucketName = bucketName;
         this.remoteImageDataFormat = imageDataFormat;
+
+        if ( this.signingRegion.equals("") ) {
+            this.signingRegion = null;
+        }
 
         if ( !this.serviceEndpoint.endsWith("/") ) {
             this.serviceEndpoint = this.serviceEndpoint + "/";

--- a/src/main/java/org/embl/mobie/viewer/projectcreator/ui/ProjectsCreatorPanel.java
+++ b/src/main/java/org/embl/mobie/viewer/projectcreator/ui/ProjectsCreatorPanel.java
@@ -342,7 +342,7 @@ public class ProjectsCreatorPanel extends JFrame {
             formats[i] = remoteFormats.get(i).toString();
         }
         gd.addChoice("Image format:", formats, formats[0]);
-        gd.addStringField("Signing Region", "us-west-2", 20);
+        gd.addStringField("Signing Region", "", 20);
         gd.addStringField("Service endpoint", "https://...", 20);
         gd.addStringField("Bucket Name", "", 20);
 

--- a/src/main/java/org/embl/mobie/viewer/source/StorageLocation.java
+++ b/src/main/java/org/embl/mobie/viewer/source/StorageLocation.java
@@ -4,4 +4,5 @@ public class StorageLocation
 {
 	public String relativePath;
 	public String s3Address;
+	public String signingRegion;
 }


### PR DESCRIPTION
fixes https://github.com/mobie/mobie-viewer-fiji/issues/614

-changes default signing region to be blank
-adds signingRegion for ome-zarr files in the style below (if blank this is omitted):
```
"ome.zarr.s3": {"s3Address": "...", "signingRegion": "us-east-1"}
```

This only writes the signing region for ome-zarr - it doesn't handle actually reading this / using it for opening ome-zarr yet! I think this will need more extensive changes though. So probably best to merge this + go ahead with the release, and I'll make a separate issue to properly read signing region for ome-zarr.