### PR TITLE
Refactor file chooser and move clear button

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
 	<groupId>org.embl.mobie</groupId>
 	<artifactId>mobie-viewer-fiji</artifactId>
-	<version>2.1.6</version>
+	<version>2.1.7-SNAPSHOT</version>
 
 	<!-- mvn clean install -Dscijava.app.directory=/Users/tischer/Desktop/Fiji/Fiji-MoBIE-beta.app -->
 	<!-- mvn clean install -Dscijava.app.directory=/Users/tischer/Desktop/Fiji/Fiji-MoBIE.app -->

--- a/src/main/java/org/embl/mobie/viewer/MoBIEUtils.java
+++ b/src/main/java/org/embl/mobie/viewer/MoBIEUtils.java
@@ -190,26 +190,38 @@ public abstract class MoBIEUtils
 
 	public static File lastSelectedDir;
 
-	private static void setLastSelectedDir( String filePath ) {
-		File selectedFile = new File( filePath );
-		if ( selectedFile.isDirectory() ) {
-			lastSelectedDir = selectedFile;
-		} else {
-			lastSelectedDir = selectedFile.getParentFile();
+	// objectName is used for the dialog labels e.g. 'table', 'bookmark' etc...
+	public static String selectFilePath( String fileExtension, String objectName, boolean open ) {
+		final JFileChooser jFileChooser = new JFileChooser( lastSelectedDir );
+		if ( fileExtension != null ) {
+			jFileChooser.setFileFilter(new FileNameExtensionFilter(fileExtension, fileExtension));
 		}
+		jFileChooser.setDialogTitle( "Select " + objectName );
+		return selectPath( jFileChooser, open );
 	}
 
 	// objectName is used for the dialog labels e.g. 'table', 'bookmark' etc...
-	public static String selectOpenPathFromFileSystem( String objectName, String fileExtension ) {
+	public static String selectDirectoryPath( String objectName, boolean open ) {
+		final JFileChooser jFileChooser = new JFileChooser( lastSelectedDir );
+		jFileChooser.setFileSelectionMode( JFileChooser.DIRECTORIES_ONLY );
+		jFileChooser.setDialogTitle( "Select " + objectName );
+		return selectPath( jFileChooser, open );
+	}
+
+	private static String selectPath( JFileChooser jFileChooser, boolean open ) {
 		final AtomicBoolean isDone = new AtomicBoolean( false );
 		final String[] path = new String[ 1 ];
 		Runnable r = () -> {
-			final JFileChooser jFileChooser = new JFileChooser( lastSelectedDir );
-			jFileChooser.setFileFilter(new FileNameExtensionFilter( fileExtension, fileExtension ));
-			path[ 0 ] = selectOpenPathFromFileSystem( objectName, jFileChooser );
+			if ( open ) {
+				path[0] = selectOpenPathFromFileSystem( jFileChooser);
+			} else {
+				path[0] = selectSavePathFromFileSystem( jFileChooser );
+			}
 			isDone.set( true );
 		};
+
 		SwingUtilities.invokeLater(r);
+
 		while ( ! isDone.get() ){
 			try {
 				Thread.sleep( 100 );
@@ -219,43 +231,31 @@ public abstract class MoBIEUtils
 		return path[ 0 ];
 	}
 
-	public static String selectOpenPathFromFileSystem( String objectName ) {
-		final JFileChooser jFileChooser = new JFileChooser( lastSelectedDir );
-		return selectOpenPathFromFileSystem( objectName, jFileChooser );
+	private static void setLastSelectedDir( String filePath ) {
+		File selectedFile = new File( filePath );
+		if ( selectedFile.isDirectory() ) {
+			lastSelectedDir = selectedFile;
+		} else {
+			lastSelectedDir = selectedFile.getParentFile();
+		}
 	}
 
-	public static String selectOpenPathFromFileSystem( String objectName, JFileChooser jFileChooser ) {
+	public static String selectOpenPathFromFileSystem( JFileChooser jFileChooser ) {
 		String filePath = null;
-		jFileChooser.setDialogTitle( "Select " + objectName );
 		if (jFileChooser.showOpenDialog(null) == JFileChooser.APPROVE_OPTION) {
 			filePath = jFileChooser.getSelectedFile().getAbsolutePath();
 			setLastSelectedDir( filePath );
 		}
-
 		return filePath;
 	}
 
-	public static String selectOpenDirFromFileSystem( String objectName ) {
-		final JFileChooser jFileChooser = new JFileChooser( lastSelectedDir );
-		return selectOpenDirFromFileSystem( objectName, jFileChooser );
-	}
-
-	public static String selectOpenDirFromFileSystem( String objectName, JFileChooser jFileChooser ) {
-		jFileChooser.setFileSelectionMode( JFileChooser.DIRECTORIES_ONLY );
-		return selectOpenPathFromFileSystem( objectName, jFileChooser );
-	}
-
-	// objectName is used for the dialog labels e.g. 'table', 'bookmark' etc...
-	public static String selectSavePathFromFileSystem( String fileExtension )
+	public static String selectSavePathFromFileSystem( JFileChooser jFileChooser )
 	{
 		String filePath = null;
-		final JFileChooser jFileChooser = new JFileChooser( lastSelectedDir );
-		jFileChooser.setFileFilter(new FileNameExtensionFilter( fileExtension, fileExtension ));
 		if (jFileChooser.showSaveDialog(null) == JFileChooser.APPROVE_OPTION) {
 			filePath = jFileChooser.getSelectedFile().getAbsolutePath();
 			setLastSelectedDir( filePath );
 		}
-
 		return filePath;
 	}
 

--- a/src/main/java/org/embl/mobie/viewer/projectcreator/ProjectCreatorHelper.java
+++ b/src/main/java/org/embl/mobie/viewer/projectcreator/ProjectCreatorHelper.java
@@ -182,7 +182,7 @@ public class ProjectCreatorHelper {
     }
 
     public static String chooseNewSelectionGroupNameDialog() {
-        final GenericDialog gd = new GenericDialog("Choose ui selection group Name:");
+        final GenericDialog gd = new GenericDialog("Choose ui selection group name:");
 
         gd.addStringField("New ui selection group name:", "", 25 );
         gd.showDialog();

--- a/src/main/java/org/embl/mobie/viewer/projectcreator/ui/ProjectsCreatorPanel.java
+++ b/src/main/java/org/embl/mobie/viewer/projectcreator/ui/ProjectsCreatorPanel.java
@@ -632,10 +632,11 @@ public class ProjectsCreatorPanel extends JFrame {
         switch ( imageDataFormat )
         {
             case BdvN5:
-                return MoBIEUtils.selectOpenPathFromFileSystem( "bdv .xml file", "xml" );
+                return MoBIEUtils.selectFilePath( "xml", "bdv .xml file", true );
 
             case OmeZarr:
-                String filePath = MoBIEUtils.selectOpenDirFromFileSystem( ".ome.zarr file" );
+                String filePath = MoBIEUtils.selectDirectoryPath( ".ome.zarr file", true );
+
                 // quick check that basic criteria for ome-zarr are met i.e. contains right files in top of dir
                 if ( ! isValidOMEZarr( filePath ) )
                 {

--- a/src/main/java/org/embl/mobie/viewer/table/TableViewer.java
+++ b/src/main/java/org/embl/mobie/viewer/table/TableViewer.java
@@ -491,28 +491,24 @@ public class TableViewer< T extends TableRow > implements SelectionListener< T >
 	{
 		final JMenuItem menuItem = new JMenuItem( "Load Columns..." );
 		menuItem.addActionListener( e ->
-				SwingUtilities.invokeLater( () ->
-				{
+				new Thread( () -> {
 					FileLocation fileLocation;
-					if ( sourceNameToTableDir.size() > 1 ) {
+					if (sourceNameToTableDir.size() > 1) {
 						// For multi-source tables, we only allow loading from the project
 						fileLocation = FileLocation.Project;
 					} else {
 						fileLocation = loadFromProjectOrFileSystemDialog();
-						if ( fileLocation == null )
+						if (fileLocation == null)
 							return;
 					}
 
 
-					if ( fileLocation == FileLocation.Project )
-					{
+					if (fileLocation == FileLocation.Project) {
 						loadColumnsFromProject();
-					}
-					else
-					{
+					} else {
 						loadColumnsFromFileSystem();
 					}
-				} ) );
+				}).start() );
 
 		return menuItem;
 	}

--- a/src/main/java/org/embl/mobie/viewer/table/TableViewer.java
+++ b/src/main/java/org/embl/mobie/viewer/table/TableViewer.java
@@ -53,10 +53,7 @@ import javax.swing.*;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableModel;
 import java.awt.*;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.awt.event.WindowAdapter;
-import java.awt.event.WindowEvent;
+import java.awt.event.*;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -459,7 +456,7 @@ public class TableViewer< T extends TableRow > implements SelectionListener< T >
 
 	private void loadColumnsFromFileSystem()
 	{
-		String path = selectOpenPathFromFileSystem( "Table" );
+		String path = selectFilePath( null, "Table", true );
 
 		if ( path != null ) {
 			new Thread( () -> {

--- a/src/main/java/org/embl/mobie/viewer/ui/UserInterfaceHelpers.java
+++ b/src/main/java/org/embl/mobie/viewer/ui/UserInterfaceHelpers.java
@@ -265,6 +265,7 @@ public class UserInterfaceHelpers
 
 		panel.add( new JSeparator( SwingConstants.HORIZONTAL ) );
 		panel.add( createMoveToLocationPanel()  );
+		panel.add( createRemoveAllViewsPanel( moBIE ) );
 
 		return panel;
 	}
@@ -425,8 +426,7 @@ public class UserInterfaceHelpers
 			}
 		}
 
-		viewSelectionPanel.add( createRemoveAllViewsPanel( moBIE ) );
-		viewsSelectionPanelHeight = ( groupingsToViews.keySet().size() + 1 ) * 40;
+		viewsSelectionPanelHeight = groupingsToViews.keySet().size() * 40;
 	}
 
 	public Map< String, Map< String, View > > getGroupingsToViews()
@@ -450,9 +450,14 @@ public class UserInterfaceHelpers
 
 	private JPanel createRemoveAllViewsPanel( MoBIE moBIE )
 	{
-		final JPanel horizontalLayoutPanel = SwingUtils.horizontalLayoutPanel();
+		JPanel panel = new JPanel();
+		panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+		panel.setBorder(BorderFactory.createEmptyBorder(0, 10, 0, 10));
+		panel.add(Box.createHorizontalGlue());
+		panel.setAlignmentX(0.0F);
 
 		final JButton button = SwingHelpers.createButton( "clear", new Dimension( 80, TEXT_FIELD_HEIGHT ) );
+		button.setAlignmentX(Component.CENTER_ALIGNMENT);
 		button.addActionListener( e ->
 		{
 			SwingUtilities.invokeLater( () ->
@@ -464,11 +469,8 @@ public class UserInterfaceHelpers
 			} );
 		} );
 
-		horizontalLayoutPanel.add( SwingHelpers.getJLabel( "" ) );
-		horizontalLayoutPanel.add( SwingHelpers.getJLabel( "" ) );
-		horizontalLayoutPanel.add( button );
-
-		return horizontalLayoutPanel;
+		panel.add( button );
+		return panel;
 	}
 
 	private JPanel createViewSelectionPanel(MoBIE moBIE, String panelName, Map< String, View > views )

--- a/src/main/java/org/embl/mobie/viewer/view/additionalviews/AdditionalViewsLoader.java
+++ b/src/main/java/org/embl/mobie/viewer/view/additionalviews/AdditionalViewsLoader.java
@@ -29,7 +29,7 @@ public class AdditionalViewsLoader {
             if ( fileLocation == MoBIEUtils.FileLocation.Project ) {
                 selectedFilePath = MoBIEUtils.selectPathFromProject( moBIE.getDatasetPath("misc", "views" ), "View" );
             } else {
-                selectedFilePath = MoBIEUtils.selectOpenPathFromFileSystem( "View" );
+                selectedFilePath = MoBIEUtils.selectFilePath( "json", "View", true );
             }
 
             if (selectedFilePath != null) {

--- a/src/main/java/org/embl/mobie/viewer/view/additionalviews/AdditionalViewsLoader.java
+++ b/src/main/java/org/embl/mobie/viewer/view/additionalviews/AdditionalViewsLoader.java
@@ -21,26 +21,27 @@ public class AdditionalViewsLoader {
     }
 
     public void loadAdditionalViewsDialog() {
-        try {
-            String selectedFilePath = null;
-            MoBIEUtils.FileLocation fileLocation = MoBIEUtils.loadFromProjectOrFileSystemDialog();
-            if ( fileLocation == null )
-                return;
-            if ( fileLocation == MoBIEUtils.FileLocation.Project ) {
-                selectedFilePath = MoBIEUtils.selectPathFromProject( moBIE.getDatasetPath("misc", "views" ), "View" );
-            } else {
-                selectedFilePath = MoBIEUtils.selectFilePath( "json", "View", true );
-            }
+        new Thread( () -> {
+            try {
+                String selectedFilePath = null;
+                MoBIEUtils.FileLocation fileLocation = MoBIEUtils.loadFromProjectOrFileSystemDialog();
+                if ( fileLocation == null )
+                    return;
+                if ( fileLocation == MoBIEUtils.FileLocation.Project ) {
+                    selectedFilePath = MoBIEUtils.selectPathFromProject( moBIE.getDatasetPath("misc", "views" ), "View" );
+                } else {
+                    selectedFilePath = MoBIEUtils.selectFilePath( "json", "View", true );
+                }
 
-            if (selectedFilePath != null) {
-                MoBIELookAndFeelToggler.setMoBIELaf();
-                loadViews( selectedFilePath );
-                MoBIELookAndFeelToggler.resetMoBIELaf();
+                if (selectedFilePath != null) {
+                    MoBIELookAndFeelToggler.setMoBIELaf();
+                    loadViews( selectedFilePath );
+                    MoBIELookAndFeelToggler.resetMoBIELaf();
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
             }
-
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+        }).start();
     }
 
     public void loadViews( String selectedFilePath ) throws IOException

--- a/src/main/java/org/embl/mobie/viewer/view/saving/ViewsSaver.java
+++ b/src/main/java/org/embl/mobie/viewer/view/saving/ViewsSaver.java
@@ -144,7 +144,7 @@ public class ViewsSaver {
     }
 
     private String chooseFileSystemJson() {
-        String jsonPath = MoBIEUtils.selectSavePathFromFileSystem( "json" );
+        String jsonPath = MoBIEUtils.selectFilePath( "json", "json file", false );
 
         if ( jsonPath != null && !jsonPath.endsWith(".json") ) {
                 jsonPath += ".json";

--- a/src/main/java/org/embl/mobie/viewer/view/saving/ViewsSaver.java
+++ b/src/main/java/org/embl/mobie/viewer/view/saving/ViewsSaver.java
@@ -154,26 +154,30 @@ public class ViewsSaver {
     }
 
     private void saveNewViewToFileSystem( View view, String viewName ) {
-        String jsonPath = chooseFileSystemJson();
-        if ( jsonPath != null ) {
-            try {
-                saveNewViewToAdditionalViewsJson( view, viewName, jsonPath );
-                addViewToUi( viewName, view );
-            } catch (IOException e) {
-                e.printStackTrace();
+        new Thread( () -> {
+            String jsonPath = chooseFileSystemJson();
+            if ( jsonPath != null ) {
+                try {
+                    saveNewViewToAdditionalViewsJson( view, viewName, jsonPath );
+                    addViewToUi( viewName, view );
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
             }
-        }
+        }).start();
     }
 
     private void overwriteExistingViewOnFileSystem( View view ) {
-        String jsonPath = chooseFileSystemJson();
-        if ( jsonPath != null ) {
-            try {
-                overwriteExistingViewInAdditionalViewsJson( view, jsonPath );
-            } catch (IOException e) {
-                e.printStackTrace();
+        new Thread( () -> {
+            String jsonPath = chooseFileSystemJson();
+            if ( jsonPath != null ) {
+                try {
+                    overwriteExistingViewInAdditionalViewsJson( view, jsonPath );
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
             }
-        }
+        }).start();
     }
 
     private void saveNewViewToProject( View view, String viewName, ProjectSaveLocation projectSaveLocation ) {


### PR DESCRIPTION
fixes https://github.com/mobie/mobie-viewer-fiji/issues/639 and https://github.com/mobie/mobie-viewer-fiji/issues/633

- refactors use of JFileChooser to always use the workaround from @tischi (I had to add ```new Thread()``` in a few more places to stop the file choosers hanging on windows)
- changes to SNAPSHOT version
- moves clear button down below location (while I was working on the file choosers, I found a bug where loading/saving views leads to multiple copies of the clear button - so I thought I'd just go ahead and move it)
![Screenshot 2022-03-11 115135](https://user-images.githubusercontent.com/24316371/157854550-45978928-a295-4255-bcd7-897051321a8a.png)

