### PR TITLE
make views match json schema

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,5 +231,11 @@
 			<version>5.4.2</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.github.erosb</groupId>
+			<artifactId>everit-json-schema</artifactId>
+			<version>1.14.1</version>
+			<scope>test</scope>
+		</dependency>
   </dependencies>
 </project>

--- a/src/main/java/org/embl/mobie/viewer/display/AnnotatedRegionDisplay.java
+++ b/src/main/java/org/embl/mobie/viewer/display/AnnotatedRegionDisplay.java
@@ -24,7 +24,7 @@ public abstract class AnnotatedRegionDisplay< T extends TableRow > extends Abstr
 	// Serialization
 	protected String lut = ColoringLuts.GLASBEY;
 	protected String colorByColumn;
-	protected Double[] valueLimits = new Double[]{ null, null };
+	protected Double[] valueLimits;
 	protected boolean showScatterPlot = false;
 	protected String[] scatterPlotAxes = new String[]{ TableColumnNames.ANCHOR_X, TableColumnNames.ANCHOR_Y };
 	protected List< String > tables; // tables to display

--- a/src/main/java/org/embl/mobie/viewer/display/SegmentationSourceDisplay.java
+++ b/src/main/java/org/embl/mobie/viewer/display/SegmentationSourceDisplay.java
@@ -108,7 +108,7 @@ public class SegmentationSourceDisplay extends AnnotatedRegionDisplay< TableRowI
 		if (currentSelectedSegments != null) {
 			ArrayList<String> selectedSegmentIds = new ArrayList<>();
 			for (TableRowImageSegment segment : currentSelectedSegments) {
-				selectedSegmentIds.add( segment.imageId() + ";" + segment.timePoint() + ";" + segment.labelId() );
+				selectedSegmentIds.add( segment.imageId() + ";" + segment.timePoint() + ";" + (int) segment.labelId() );
 			}
 			this.selectedSegmentIds = selectedSegmentIds;
 		}

--- a/src/test/java/org/embl/mobie/viewer/serialize/DatasetJsonParserTest.java
+++ b/src/test/java/org/embl/mobie/viewer/serialize/DatasetJsonParserTest.java
@@ -1,0 +1,106 @@
+package org.embl.mobie.viewer.serialize;
+
+import de.embl.cba.tables.FileAndUrlUtils;
+import net.imagej.ImageJ;
+import org.embl.mobie.io.ImageDataFormat;
+import org.embl.mobie.viewer.Dataset;
+import org.embl.mobie.viewer.MoBIE;
+import org.embl.mobie.viewer.MoBIESettings;
+import org.embl.mobie.viewer.source.ImageSource;
+import org.embl.mobie.viewer.source.SourceSupplier;
+import org.embl.mobie.viewer.source.StorageLocation;
+import org.embl.mobie.viewer.view.View;
+import org.everit.json.schema.Schema;
+import org.everit.json.schema.loader.SchemaLoader;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+class DatasetJsonParserTest {
+
+    private File tempDir;
+    private static JSONObject datasetSchema;
+    private Dataset dataset;
+    private final String viewName = "default";
+    private final String uiSelectionGroup = "bookmark";
+    private final boolean isExclusive = true;
+    private DatasetJsonParser datasetJsonParser;
+    private String datasetJsonName = "dataset.json";
+
+    @BeforeAll
+    static void downloadSchema() throws IOException {
+        try( InputStream schemaInputStream = FileAndUrlUtils.getInputStream(
+                "https://raw.githubusercontent.com/mobie/mobie.github.io/master/schema/dataset.schema.json") ) {
+            datasetSchema = new JSONObject(new JSONTokener(schemaInputStream));
+        }
+    }
+
+    @BeforeEach
+    void setUp( @TempDir Path tempDir ) throws IOException {
+        this.tempDir = tempDir.toFile();
+        datasetJsonParser = new DatasetJsonParser();
+        dataset = new Dataset();
+        dataset.sources = new HashMap<>();
+
+        ImageSource imageSource = new ImageSource();
+        StorageLocation storageLocation = new StorageLocation();
+        storageLocation.relativePath = "an/example/path";
+        imageSource.imageData = new HashMap<>();
+        imageSource.imageData.put( ImageDataFormat.BdvN5, storageLocation);
+        SourceSupplier sourceSupplier = new SourceSupplier( imageSource );
+
+        dataset.sources.put("testSource", sourceSupplier );
+
+    }
+
+    void validateJSON( String jsonPath ) throws IOException {
+
+        try( InputStream jsonInputStream = new FileInputStream( jsonPath ) ) {
+            JSONObject jsonSubject = new JSONObject(new JSONTokener(jsonInputStream));
+
+            // library only supports up to draft 7 json schema - specify here, otherwise errors when reads 2020-12 in
+            // the schema file
+            SchemaLoader loader = SchemaLoader.builder()
+                    .schemaJson(datasetSchema)
+                    .draftV7Support()
+                    .build();
+            Schema schema = loader.load().build();
+
+            schema.validate(jsonSubject);
+        }
+    }
+
+    @Test
+    public void savePlatyView() throws IOException
+    {
+        final ImageJ imageJ = new ImageJ();
+        imageJ.ui().showUI();
+
+        final MoBIE moBIE = new MoBIE("https://github.com/mobie/platybrowser-project", MoBIESettings.settings());
+
+        // show a view with a segmentation and selected cells that loads fast, to test saving
+        final Map< String, View > views = moBIE.getViews();
+        moBIE.getViewManager().show( views.get("Suppl. Fig. 2A: Neuron" ) );
+
+        // grab the current view and save it
+        View view  = moBIE.getViewManager().getCurrentView( uiSelectionGroup, isExclusive, true );
+        dataset.views = new HashMap<>();
+        dataset.views.put( viewName, view );
+
+        String jsonPath = new File( tempDir, datasetJsonName ).getAbsolutePath();
+        datasetJsonParser.saveDataset( dataset, jsonPath );
+
+        validateJSON(jsonPath);
+    }
+}


### PR DESCRIPTION
fixes https://github.com/mobie/mobie-viewer-fiji/issues/672

- saves selectedSegmentIds as int
- doesn't serialise null valueLimits
- Adds a test to open a view from the platybrowser, save it, and verify this against the dataset json schema