### PR TITLE
Saving merged grid view

### DIFF
--- a/src/main/java/org/embl/mobie/viewer/bdv/view/AnnotatedRegionSliceView.java
+++ b/src/main/java/org/embl/mobie/viewer/bdv/view/AnnotatedRegionSliceView.java
@@ -17,6 +17,7 @@ import sc.fiji.bdvpg.services.SourceAndConverterServices;
 
 import javax.swing.*;
 import java.awt.*;
+import java.util.Collection;
 import java.util.HashMap;
 
 
@@ -74,6 +75,12 @@ public abstract class AnnotatedRegionSliceView< T extends TableRow > implements 
 		}
 		display.sourceNameToSourceAndConverter.clear();
 	};
+
+	public boolean isDisplayVisible() {
+		Collection<SourceAndConverter<?>> sourceAndConverters = display.sourceNameToSourceAndConverter.values();
+		// check if first source is visible
+		return SourceAndConverterServices.getBdvDisplayService().isVisible( sourceAndConverters.iterator().next(), bdvHandle );
+	}
 
 	@Override
 	public synchronized void coloringChanged()

--- a/src/main/java/org/embl/mobie/viewer/bdv/view/ImageSliceView.java
+++ b/src/main/java/org/embl/mobie/viewer/bdv/view/ImageSliceView.java
@@ -21,6 +21,7 @@ import sc.fiji.bdvpg.services.SourceAndConverterServices;
 import sc.fiji.bdvpg.sourceandconverter.display.ColorChanger;
 import sc.fiji.bdvpg.sourceandconverter.display.ConverterChanger;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -122,6 +123,12 @@ public class ImageSliceView
 				}
 			}
 		}
+	}
+
+	public boolean isDisplayVisible() {
+		Collection<SourceAndConverter<?>> sourceAndConverters = display.sourceNameToSourceAndConverter.values();
+		// check if first source is visible
+		return SourceAndConverterServices.getBdvDisplayService().isVisible( sourceAndConverters.iterator().next(), bdvHandle );
 	}
 
 	public void close( boolean closeImgLoader )

--- a/src/main/java/org/embl/mobie/viewer/display/AnnotatedRegionDisplay.java
+++ b/src/main/java/org/embl/mobie/viewer/display/AnnotatedRegionDisplay.java
@@ -11,6 +11,7 @@ import org.embl.mobie.viewer.bdv.render.BlendingMode;
 import org.embl.mobie.viewer.bdv.view.AnnotatedRegionSliceView;
 import org.embl.mobie.viewer.color.LabelConverter;
 import org.embl.mobie.viewer.color.MoBIEColoringModel;
+import org.embl.mobie.viewer.color.OpacityAdjuster;
 import org.embl.mobie.viewer.plot.ScatterPlotViewer;
 import org.embl.mobie.viewer.source.LabelSource;
 import org.embl.mobie.viewer.table.TableViewer;
@@ -106,10 +107,10 @@ public abstract class AnnotatedRegionDisplay< T extends TableRow > extends Abstr
 
 		final SourceAndConverter< ? > sourceAndConverter = annotatedRegionDisplay.sourceNameToSourceAndConverter.values().iterator().next();
 
-		if( sourceAndConverter.getConverter() instanceof LabelConverter)
+		if( sourceAndConverter.getConverter() instanceof OpacityAdjuster )
 		{
-			final LabelConverter labelConverter = ( LabelConverter ) sourceAndConverter.getConverter();
-			this.opacity = labelConverter.getOpacity();
+			final OpacityAdjuster opacityAdjuster = ( OpacityAdjuster ) sourceAndConverter.getConverter();
+			this.opacity = opacityAdjuster.getOpacity();
 		}
 
 		this.lut = annotatedRegionDisplay.coloringModel.getARGBLutName();

--- a/src/main/java/org/embl/mobie/viewer/display/AnnotatedSourceDisplay.java
+++ b/src/main/java/org/embl/mobie/viewer/display/AnnotatedSourceDisplay.java
@@ -99,6 +99,10 @@ public class AnnotatedSourceDisplay extends AnnotatedRegionDisplay< AnnotatedMas
 
 		this.tableData = new HashMap<>();
 		this.tableData.putAll( annotatedSourceDisplay.tableData );
+
+		if ( annotatedSourceDisplay.sliceView != null ) {
+			this.visible = annotatedSourceDisplay.sliceView.isDisplayVisible();
+		}
 	}
 
 }

--- a/src/main/java/org/embl/mobie/viewer/display/ImageSourceDisplay.java
+++ b/src/main/java/org/embl/mobie/viewer/display/ImageSourceDisplay.java
@@ -44,6 +44,8 @@ public class ImageSourceDisplay extends AbstractSourceDisplay
 		return blendingMode;
 	}
 
+	public Double[] getResolution3dView() { return resolution3dView; }
+
 	public boolean showImagesIn3d()
 	{
 		return showImagesIn3d;

--- a/src/main/java/org/embl/mobie/viewer/display/ImageSourceDisplay.java
+++ b/src/main/java/org/embl/mobie/viewer/display/ImageSourceDisplay.java
@@ -2,6 +2,7 @@ package org.embl.mobie.viewer.display;
 
 import bdv.tools.brightness.ConverterSetup;
 import bdv.viewer.SourceAndConverter;
+import org.embl.mobie.viewer.MoBIE;
 import org.embl.mobie.viewer.bdv.view.ImageSliceView;
 import org.embl.mobie.viewer.bdv.render.BlendingMode;
 import org.embl.mobie.viewer.color.opacity.AdjustableOpacityColorConverter;
@@ -21,6 +22,7 @@ public class ImageSourceDisplay extends AbstractSourceDisplay
 	private double[] contrastLimits;
 	private BlendingMode blendingMode;
 	private boolean showImagesIn3d;
+	private Double[] resolution3dView;
 
 	// Runtime
 	public transient ImageSliceView imageSliceView;
@@ -81,7 +83,22 @@ public class ImageSourceDisplay extends AbstractSourceDisplay
 
 		setDisplaySettings( sourceAndConverter );
 
-		// TODO - show images in 3d (currently not supported in viewer)
+		if ( imageDisplay.imageVolumeViewer != null )
+		{
+			this.showImagesIn3d = imageDisplay.imageVolumeViewer.getShowImages();
+
+			double[] voxelSpacing = imageDisplay.imageVolumeViewer.getVoxelSpacing();
+			if ( voxelSpacing != null ) {
+				resolution3dView = new Double[voxelSpacing.length];
+				for (int i = 0; i < voxelSpacing.length; i++) {
+					resolution3dView[i] = voxelSpacing[i];
+				}
+			}
+		}
+
+		if ( imageDisplay.imageSliceView != null ) {
+			visible = imageDisplay.imageSliceView.isDisplayVisible();
+		}
 	}
 
 	public ImageSourceDisplay( SourceAndConverter< ? > sourceAndConverter )

--- a/src/main/java/org/embl/mobie/viewer/display/SegmentationSourceDisplay.java
+++ b/src/main/java/org/embl/mobie/viewer/display/SegmentationSourceDisplay.java
@@ -104,5 +104,9 @@ public class SegmentationSourceDisplay extends AnnotatedRegionDisplay< TableRowI
 			}
 			this.selectedSegmentIds = selectedSegmentIds;
 		}
+
+		if ( segmentationDisplay.sliceView != null ) {
+			visible = segmentationDisplay.sliceView.isDisplayVisible();
+		}
 	}
 }

--- a/src/main/java/org/embl/mobie/viewer/serialize/SourceTransformerListAdapter.java
+++ b/src/main/java/org/embl/mobie/viewer/serialize/SourceTransformerListAdapter.java
@@ -54,6 +54,8 @@ public class SourceTransformerListAdapter implements JsonSerializer< List<Source
 				ja.add( context.serialize( nameToTransformer , new TypeToken< Map< String, AffineSourceTransformer > >() {}.getType() ) );
 			} else if ( sourceTransformer instanceof CropSourceTransformer ) {
 				ja.add( context.serialize( nameToTransformer , new TypeToken< Map< String, CropSourceTransformer > >() {}.getType() ) );
+			} else if ( sourceTransformer instanceof MergedGridSourceTransformer ) {
+				ja.add( context.serialize( nameToTransformer, new TypeToken< Map< String, MergedGridSourceTransformer > >(){}.getType()) );
 			} else {
 				throw new UnsupportedOperationException( "Could not serialise SourceTransformer of type: " + sourceTransformer.getClass().toString() );
 			}

--- a/src/main/java/org/embl/mobie/viewer/view/ViewManager.java
+++ b/src/main/java/org/embl/mobie/viewer/view/ViewManager.java
@@ -387,6 +387,12 @@ public class ViewManager
 	private void initImageVolumeViewer( ImageSourceDisplay imageDisplay )
 	{
 		imageDisplay.imageVolumeViewer = new ImageVolumeViewer( imageDisplay.sourceNameToSourceAndConverter, universeManager );
+		Double[] resolution3dView = imageDisplay.getResolution3dView();
+		if ( resolution3dView != null ) {
+			imageDisplay.imageVolumeViewer.setVoxelSpacing( ArrayUtils.toPrimitive(imageDisplay.getResolution3dView() ));
+		}
+		imageDisplay.imageVolumeViewer.showImages( imageDisplay.showImagesIn3d() );
+
 		for ( SourceAndConverter< ? > sourceAndConverter : imageDisplay.sourceNameToSourceAndConverter.values() )
 		{
 			sacService.setMetadata( sourceAndConverter, ImageVolumeViewer.class.getName(), imageDisplay.imageVolumeViewer );

--- a/src/main/java/org/embl/mobie/viewer/volume/ImageVolumeViewer.java
+++ b/src/main/java/org/embl/mobie/viewer/volume/ImageVolumeViewer.java
@@ -377,6 +377,8 @@ public class ImageVolumeViewer
 		return voxelSpacing;
 	}
 
+	public boolean getShowImages() { return showImages; }
+
 	public void close()
 	{
 		showImages( false );


### PR DESCRIPTION
Fixes https://github.com/mobie/mobie-viewer-fiji/issues/712 
While I was at it,  I noticed there were a few other parts that weren't being saved properly to views, so I fixed them too.

Main changes:
- Fix saving views containing merged grids
- saves displaying images in 3D / their resolution to views
- saves whether a source is visible in the slice viewer to views
- Fixes saving opacity of sourceAnnotationDisplay