### PR TITLE
Update OpenMoBIEProjectWithS3CredentialsCommand.java

### DIFF
--- a/src/main/java/org/embl/mobie/viewer/command/OpenMoBIEProjectWithS3CredentialsCommand.java
+++ b/src/main/java/org/embl/mobie/viewer/command/OpenMoBIEProjectWithS3CredentialsCommand.java
@@ -39,7 +39,7 @@ import java.io.IOException;
 @Plugin(type = Command.class, menuPath = CommandConstants.MOBIE_PLUGIN_ROOT + "Open>Advanced>Open MoBIE Project With S3 Credentials..." )
 public class OpenMoBIEProjectWithS3CredentialsCommand implements Command
 {
-	@Parameter ( label = "S3 Project Location" )
+	@Parameter ( label = "Project Location" )
 	public String projectLocation = "https://s3.embl.de/comulis";
 
 	@Parameter ( label = "S3 Access Key" )


### PR DESCRIPTION
Rename "S3 Project Location" to "Project Location": Calling it project location is confusing, since it implies that only projects stored on S3 can be loaded this way. But that's not the case, both projects from only S3 and from github + S3 (where the project location is the github address) are supported. I just checked and this indeed works.