### PR TITLE
issue786: LazySourceAndConverter

### DIFF
--- a/src/main/java/org/embl/mobie/viewer/MoBIE.java
+++ b/src/main/java/org/embl/mobie/viewer/MoBIE.java
@@ -48,6 +48,7 @@ import org.embl.mobie.viewer.plugins.platybrowser.GeneSearchCommand;
 import org.embl.mobie.viewer.serialize.DatasetJsonParser;
 import org.embl.mobie.viewer.serialize.ProjectJsonParser;
 import org.embl.mobie.viewer.source.ImageSource;
+import org.embl.mobie.viewer.source.LazySourceAndConverter;
 import org.embl.mobie.viewer.source.SegmentationSource;
 import org.embl.mobie.viewer.table.TableDataFormat;
 import org.embl.mobie.viewer.table.TableHelper;
@@ -77,8 +78,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static org.embl.mobie.viewer.MoBIEHelper.selectCommonTableFileNameFromProject;
 import static org.embl.mobie.viewer.MoBIEHelper.selectFilePath;
+import static org.embl.mobie.viewer.MoBIEHelper.selectTableFileNameFromProject;
 
 public class MoBIE
 {
@@ -159,7 +160,7 @@ public class MoBIE
 	public String appendColumnsFromProject( AnnotationDisplay< ? extends TableRow > display )
 	{
 		final Map< String, String > sourceNameToTableDirectory = getTableDirectories( display );
-		String tableFileName = selectCommonTableFileNameFromProject( sourceNameToTableDirectory.values(), "Table" );
+		String tableFileName = selectTableFileNameFromProject( sourceNameToTableDirectory.values(), "Table" );
 
 		if ( display instanceof RegionDisplay )
 		{
@@ -484,6 +485,13 @@ public class MoBIE
 
 	public SourceAndConverter< ? > openSourceAndConverter( String sourceName, String log )
 	{
+		boolean isLazy = true;
+		if ( isLazy )
+		{
+			final LazySourceAndConverter< Object > lazySac = new LazySourceAndConverter<>();
+			return lazySac;
+		}
+
 		final ImageSource imageSource = getSource( sourceName );
 
 		ImageDataFormat imageDataFormat = getImageDataFormat( sourceName, imageSource.imageData.keySet() );

--- a/src/main/java/org/embl/mobie/viewer/MoBIEHelper.java
+++ b/src/main/java/org/embl/mobie/viewer/MoBIEHelper.java
@@ -199,7 +199,7 @@ public abstract class MoBIEHelper
 		FileSystem
 	}
 
-	private static String chooseValidTableFileName( List<String> directories, String objectName ) {
+	private static String chooseValidTableFileName( Collection< String > directories, String objectName ) {
 		ArrayList< String > commonFileNames = getCommonFileNames( directories );
 		if ( commonFileNames.size() > 0 ) {
 			String[] choices = new String[commonFileNames.size()];
@@ -213,7 +213,7 @@ public abstract class MoBIEHelper
 	}
 
 	// find file names that occur in all directories
-	private static ArrayList< String > getCommonFileNames( List< String > directories )
+	private static ArrayList< String > getCommonFileNames( Collection< String > directories )
 	{
 		Map<String, Integer> fileNameCounts = new HashMap<>();
 		ArrayList<String> commonFileNames = new ArrayList<>();
@@ -246,7 +246,7 @@ public abstract class MoBIEHelper
 		return FileLocation.valueOf(gd.getNextChoice());
 	}
 
-	public static String selectTableFileNameFromProject( List<String> directories, String objectName ) {
+	public static String selectTableFileNameFromProject( Collection<String> directories, String objectName ) {
 		if ( directories == null )
 			return null;
 
@@ -254,9 +254,10 @@ public abstract class MoBIEHelper
 			// when there are multiple directories,
 			// we only allow selection of table file names
 			// that are present in all directories
-			return chooseValidTableFileName(directories, objectName);
+			return chooseValidTableFileName( directories, objectName );
 		} else {
-			String[] fileNames = IOHelper.getFileNames( directories.get(0) );
+			final String directory = directories.iterator().next();
+			String[] fileNames = IOHelper.getFileNames( directory );
 			if ( fileNames == null )
 				throw new RuntimeException("Could not find any files at " + directory );
 			return selectionDialog( fileNames, objectName );

--- a/src/main/java/org/embl/mobie/viewer/playground/SourceAffineTransformer.java
+++ b/src/main/java/org/embl/mobie/viewer/playground/SourceAffineTransformer.java
@@ -70,7 +70,8 @@ public class SourceAffineTransformer implements Runnable, Function<SourceAndConv
      * Constructor without any source argument in order to use the functional interface only
      * @param at3D affine transform 3d
      */
-    public SourceAffineTransformer( AffineTransform3D at3D ) {
+    public SourceAffineTransformer( AffineTransform3D at3D )
+    {
         this.at3D = at3D;
     }
 
@@ -79,7 +80,8 @@ public class SourceAffineTransformer implements Runnable, Function<SourceAndConv
      * @param at3D
      * @param name
      */
-    public SourceAffineTransformer( AffineTransform3D at3D, String name ) {
+    public SourceAffineTransformer( AffineTransform3D at3D, String name )
+    {
         this.at3D = at3D;
         this.name = name;
     }
@@ -93,23 +95,20 @@ public class SourceAffineTransformer implements Runnable, Function<SourceAndConv
         return apply(sourceIn);//sourceOut;
     }
 
-    public SourceAndConverter apply(SourceAndConverter in) {
-        SourceAndConverter sac;
+    public SourceAndConverter apply( SourceAndConverter in ) {
 
         TransformedSource src = getTransformedSource( in );
 
-        // TODO: can I use the SourceChanger for this??
-        if (in.asVolatile()!=null)
+        if ( in.asVolatile() !=null )
         {
-            TransformedSource vsrc = new TransformedSource(in.asVolatile().getSpimSource(), src);
-            SourceAndConverter vout = new SourceAndConverter<>(vsrc, SourceAndConverterHelper.cloneConverter(in.asVolatile().getConverter(), in.asVolatile()));
-            sac = new SourceAndConverter<>(src, SourceAndConverterHelper.cloneConverter(in.getConverter(), in), vout);
+            TransformedSource vsrc = new TransformedSource( in.asVolatile().getSpimSource(), src );
+            SourceAndConverter vout = new SourceAndConverter<>( vsrc, SourceAndConverterHelper.cloneConverter( in.asVolatile().getConverter(), in.asVolatile() ) );
+            return new SourceAndConverter<>( src, SourceAndConverterHelper.cloneConverter( in.getConverter(), in ), vout );
         }
         else
         {
-            sac = new SourceAndConverter<>(src, SourceAndConverterHelper.cloneConverter(in.getConverter(), in));
+            return new SourceAndConverter<>( src, SourceAndConverterHelper.cloneConverter( in.getConverter(), in ));
         }
-        return sac;
     }
 
     private TransformedSource getTransformedSource( SourceAndConverter in )

--- a/src/main/java/org/embl/mobie/viewer/source/LazySourceAndConverter.java
+++ b/src/main/java/org/embl/mobie/viewer/source/LazySourceAndConverter.java
@@ -1,0 +1,36 @@
+package org.embl.mobie.viewer.source;
+
+import bdv.viewer.Source;
+import bdv.viewer.SourceAndConverter;
+import de.embl.cba.bdv.utils.sources.LazySpimSource;
+
+
+/**
+ * Needed functions by MergedGridSource without loading data:
+ *
+ * for reference source:
+ * - getSourceTransform()
+ * - rai.dimensionsAsLongArray() // could be provided by dedicated method in LazySource.
+ *
+ * in fact the other sources are not needed it seems...
+ *
+ * However, for transforming all the individual ones,
+ * one needs the SpimSource and the Converters, which is crazy.
+ * Can one do this another way? E.g. could the MergedGridSource
+ * provide the positions of those sources?
+ *
+ * @param <T>
+ */
+public class LazySourceAndConverter< T > extends SourceAndConverter< T >
+{
+	public LazySourceAndConverter( )
+	{
+		super( null );
+	}
+
+	@Override
+	public Source< T > getSpimSource()
+	{
+		return spimSource;
+	}
+}

--- a/src/main/java/org/embl/mobie/viewer/table/TableViewer.java
+++ b/src/main/java/org/embl/mobie/viewer/table/TableViewer.java
@@ -470,7 +470,7 @@ public class TableViewer< T extends TableRow > implements SelectionListener< T >
 		}
 	}
 
-	private void enableRowSorting( boolean sortable )
+	public void enableRowSorting( boolean sortable )
 	{
 		final int columnCount = jTable.getColumnCount();
 		for ( int i = 0; i < columnCount; i++ )

--- a/src/main/java/org/embl/mobie/viewer/transform/MergedGridSource.java
+++ b/src/main/java/org/embl/mobie/viewer/transform/MergedGridSource.java
@@ -92,7 +92,8 @@ public class MergedGridSource< T extends NativeType< T > & NumericType< T > > im
 		this.mergedGridSourceName = mergedGridSourceName;
 		this.type = referenceSource.getType();
 
-		mergedRandomAccessibleIntervals = createMergedRAIs();
+		initDimensions();
+		mergedRandomAccessibleIntervals = createMergedRAIs( referenceSource.getNumMipmapLevels() );
 	}
 
 	public static boolean instanceOf( SourceAndConverter< ? > sourceAndConverter )
@@ -123,13 +124,12 @@ public class MergedGridSource< T extends NativeType< T > & NumericType< T > > im
 		return gridSources;
 	}
 
-	private List< RandomAccessibleInterval< T > > createMergedRAIs()
+	private void initDimensions()
 	{
 		final int numMipmapLevels = referenceSource.getNumMipmapLevels();
 		setCellDimensions( numMipmapLevels );
 		setCellRealDimensions( cellDimensions[ 0 ] );
 		setMask( positions, cellDimensions[ 0 ] );
-		return createMergedRAIs( numMipmapLevels );
 	}
 
 	private List< RandomAccessibleInterval< T > > createMergedRAIs( int numMipmapLevels )

--- a/src/main/java/org/embl/mobie/viewer/view/ViewManager.java
+++ b/src/main/java/org/embl/mobie/viewer/view/ViewManager.java
@@ -56,6 +56,7 @@ import org.embl.mobie.viewer.select.MoBIESelectionModel;
 import org.embl.mobie.viewer.source.LabelSource;
 import org.embl.mobie.viewer.table.TableViewer;
 import org.embl.mobie.viewer.transform.AffineSourceTransformer;
+import org.embl.mobie.viewer.transform.MergedGridSource;
 import org.embl.mobie.viewer.transform.SliceViewLocationChanger;
 import org.embl.mobie.viewer.transform.NormalizedAffineViewerTransform;
 import org.embl.mobie.viewer.transform.SourceTransformer;
@@ -295,6 +296,9 @@ public class ViewManager
 		// open all raw sources
 		Map< String, SourceAndConverter< ? > > sourceNameToSourceAndConverters = moBIE.openSourceAndConverters( rawSources );
 
+		// add lazy sources
+		//sourceNameToSourceAndConverters.put( sourceName, openSourceAndConverter( sourceName, log ) );
+
 		// create transformed sources
 		final List< SourceTransformer > sourceTransformers = view.getSourceTransforms();
 		if ( sourceTransformers != null )
@@ -330,7 +334,15 @@ public class ViewManager
 
 		for ( SourceTransformer sourceTransformer : view.getSourceTransforms() )
 		{
-			sources.addAll( sourceTransformer.getSources() );
+			if ( sourceTransformer instanceof MergedGridSource )
+			{
+				// lazy (maybe return Map< String, boolean > instead of Set)
+				// boolean = isLazy or not
+			}
+			else
+			{
+				sources.addAll( sourceTransformer.getSources() );
+			}
 		}
 
 		return sources;
@@ -451,8 +463,6 @@ public class ViewManager
 
 		if ( segmentationDisplay.tableRows != null )
 		{
-			// TODO: can one use the same code here for
-			//  annotation and segmentation?
 			initTableViewer( segmentationDisplay );
 			initScatterPlotViewer( segmentationDisplay );
 			initSegmentationVolumeViewer( segmentationDisplay );


### PR DESCRIPTION
`adaptPosition( position, selection.imageId() );` in `SegmentationSliceView` seems to be the only reason why we currently need to transform all the individual sources in the `MergedGridView`. If we could get rid of this, loading the sources would be much faster as this could be done lazily.