### PR TITLE
fix dataset creator errors

### DIFF
--- a/src/main/java/org/embl/mobie/viewer/serialize/DataSourceMapAdapter.java
+++ b/src/main/java/org/embl/mobie/viewer/serialize/DataSourceMapAdapter.java
@@ -28,18 +28,10 @@
  */
 package org.embl.mobie.viewer.serialize;
 
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
-import com.google.gson.JsonSerializationContext;
-import com.google.gson.JsonSerializer;
+import com.google.gson.*;
 
 import java.lang.reflect.Type;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.TreeMap;
+import java.util.*;
 
 public class DataSourceMapAdapter implements JsonSerializer< Map< String, DataSource > >, JsonDeserializer< Map< String, DataSource > >
 {
@@ -73,8 +65,16 @@ public class DataSourceMapAdapter implements JsonSerializer< Map< String, DataSo
 
 	@Override
 	public JsonElement serialize( Map< String, DataSource > sources, Type type, JsonSerializationContext context ) {
-		// TODO
-		throw new UnsupportedOperationException("Serialization of Map< String, Data > is not yet implemented.");
-		// return null;
+
+		JsonObject jo = new JsonObject();
+		for ( Map.Entry<String, DataSource> entry : sources.entrySet() ) {
+
+			Map<String, DataSource> typeOfSourceToSource = new HashMap<>();
+			typeOfSourceToSource.put( classToName.get( entry.getValue().getClass().getName() ), entry.getValue() );
+
+			jo.add( entry.getKey(), context.serialize( typeOfSourceToSource ) );
+		}
+
+		return jo;
 	}
 }

--- a/src/test/java/org/embl/mobie/viewer/create/DatasetsCreatorTest.java
+++ b/src/test/java/org/embl/mobie/viewer/create/DatasetsCreatorTest.java
@@ -26,11 +26,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-package org.embl.mobie.viewer.projectcreator;
+package org.embl.mobie.viewer.create;
 
 import org.embl.mobie.io.util.IOHelper;
-import org.embl.mobie.viewer.create.DatasetsCreator;
-import org.embl.mobie.viewer.create.ProjectCreator;
 import org.embl.mobie.viewer.serialize.Dataset;
 import org.embl.mobie.viewer.serialize.Project;
 import org.embl.mobie.viewer.serialize.DatasetJsonParser;

--- a/src/test/java/org/embl/mobie/viewer/create/ImagesCreatorTest.java
+++ b/src/test/java/org/embl/mobie/viewer/create/ImagesCreatorTest.java
@@ -26,7 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-package org.embl.mobie.viewer.projectcreator;
+package org.embl.mobie.viewer.create;
 
 import ij.ImagePlus;
 import mpicbg.spim.data.SpimData;
@@ -38,9 +38,6 @@ import org.embl.mobie.io.n5.util.DownsampleBlock;
 import org.embl.mobie.io.n5.writers.WriteImagePlusToN5;
 import org.embl.mobie.io.ome.zarr.writers.imageplus.WriteImagePlusToN5OmeZarr;
 import org.embl.mobie.io.util.IOHelper;
-import org.embl.mobie.viewer.create.ImagesCreator;
-import org.embl.mobie.viewer.create.ProjectCreator;
-import org.embl.mobie.viewer.create.ProjectCreatorHelper;
 import org.embl.mobie.viewer.serialize.Dataset;
 import org.embl.mobie.viewer.serialize.DatasetJsonParser;
 import org.embl.mobie.viewer.serialize.ImageDataSource;
@@ -56,8 +53,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
-import static org.embl.mobie.viewer.projectcreator.ProjectCreatorTestHelper.makeImage;
-import static org.embl.mobie.viewer.projectcreator.ProjectCreatorTestHelper.makeSegmentation;
+import static org.embl.mobie.viewer.create.ProjectCreatorTestHelper.makeImage;
+import static org.embl.mobie.viewer.create.ProjectCreatorTestHelper.makeSegmentation;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/src/test/java/org/embl/mobie/viewer/create/ProjectCreatorTestHelper.java
+++ b/src/test/java/org/embl/mobie/viewer/create/ProjectCreatorTestHelper.java
@@ -26,7 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-package org.embl.mobie.viewer.projectcreator;
+package org.embl.mobie.viewer.create;
 
 import ij.IJ;
 import ij.ImagePlus;

--- a/src/test/java/org/embl/mobie/viewer/create/RemoteMetadataCreatorTest.java
+++ b/src/test/java/org/embl/mobie/viewer/create/RemoteMetadataCreatorTest.java
@@ -26,14 +26,11 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-package org.embl.mobie.viewer.projectcreator;
+package org.embl.mobie.viewer.create;
 
 import mpicbg.spim.data.SpimDataException;
 import org.embl.mobie.io.ImageDataFormat;
 import org.embl.mobie.io.util.IOHelper;
-import org.embl.mobie.viewer.create.ProjectCreator;
-import org.embl.mobie.viewer.create.ProjectCreatorHelper;
-import org.embl.mobie.viewer.create.RemoteMetadataCreator;
 import org.embl.mobie.viewer.serialize.Dataset;
 import org.embl.mobie.viewer.serialize.DatasetJsonParser;
 import net.imglib2.realtransform.AffineTransform3D;


### PR DESCRIPTION
Fixes https://github.com/mobie/mobie-viewer-fiji/issues/830

- implemented ```JsonSerializer``` for ```DataSourceMapAdapter```
- renamed project creator test folders to match new mobie structure
