### PR TITLE
Improve ColorByColumn GUI

### DIFF
--- a/src/main/java/org/embl/mobie/MoBIESettings.java
+++ b/src/main/java/org/embl/mobie/MoBIESettings.java
@@ -28,14 +28,11 @@
  */
 package org.embl.mobie;
 
-import org.embl.mobie.io.ImageDataFormat;
 import org.embl.mobie.lib.io.DataFormats;
 import org.embl.mobie.lib.serialize.View;
 import org.embl.mobie.lib.table.TableDataFormat;
 
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 public class MoBIESettings

--- a/src/main/java/org/embl/mobie/lib/SourcesFromTableCreator.java
+++ b/src/main/java/org/embl/mobie/lib/SourcesFromTableCreator.java
@@ -71,9 +71,9 @@ public class SourcesFromTableCreator
 				String fileName = table.getString( 0, imageColumn);
 				String relativeFolder = table.getString( 0, imageColumn.replace(  "FileName_", "PathName_" ) );
 				String referenceImagePath = MoBIEHelper.createAbsolutePath( root, fileName, relativeFolder );
-				IJ.log( "Determining number of channels of " + imageColumn + ", using " + referenceImagePath + "..." );
+				IJ.log( "Determining number of channels of " + imageColumn + " from " + referenceImagePath + "..." );
 				int numChannels = MoBIEHelper.getMetadataFromImageFile( referenceImagePath, 0 ).numChannelsContainer;
-				IJ.log( "Number of channels is " + numChannels );
+				IJ.log( "Number of channels: " + numChannels );
 				for ( int channelIndex = 0; channelIndex < numChannels; channelIndex++ )
 				{
 					imageFileSources.add( new ImageFileSources( imageColumn + "_C" + channelIndex, table, imageColumn, channelIndex, root, gridType ) );

--- a/src/main/java/org/embl/mobie/lib/color/ColoringModels.java
+++ b/src/main/java/org/embl/mobie/lib/color/ColoringModels.java
@@ -91,7 +91,7 @@ public class ColoringModels
 
 		if ( showUI )
 			SwingUtilities.invokeLater( () ->
-				new NumericColoringModelDialog( columnName, coloringModel ) );
+				new NumericColoringModelContrastDialog( columnName, coloringModel ) );
 
 		return coloringModel;
 	}

--- a/src/main/java/org/embl/mobie/lib/color/NumericColoringModelContrastDialog.java
+++ b/src/main/java/org/embl/mobie/lib/color/NumericColoringModelContrastDialog.java
@@ -35,11 +35,11 @@ import de.embl.cba.tables.color.ColoringListener;
 import javax.swing.*;
 import java.awt.*;
 
-public class NumericColoringModelDialog extends JFrame implements ColoringListener
+public class NumericColoringModelContrastDialog extends JFrame implements ColoringListener
 {
 	public static Point dialogLocation;
 
-	public NumericColoringModelDialog(
+	public NumericColoringModelContrastDialog(
 			final String coloringFeature,
 			final NumericAnnotationColoringModel< ? > coloringModel )
 	{

--- a/src/main/java/org/embl/mobie/lib/color/lut/LUTs.java
+++ b/src/main/java/org/embl/mobie/lib/color/lut/LUTs.java
@@ -51,17 +51,6 @@ public class LUTs
 	public static final ARGBType TRANSPARENT = new ARGBType( ARGBType.rgba( 0, 0, 0, 0 ) );
 	public static final ARGBType DARK_GREY = new ARGBType( ARGBType.rgba( 100, 100, 100, 255 ) );
 
-	public static boolean isNumeric( String lut )
-	{
-		return lut.contains( BLUE_WHITE_RED ) || lut.contains( VIRIDIS );
-	}
-
-	public static boolean isCategorical( String lut )
-	{
-		return lut.contains( GLASBEY ) || lut.contains( ARGB_COLUMN ) || lut.contains( RGBA_COLUMN );
-	}
-
-
 	public static ARGBLut getLut( String lutName )
 	{
 		// we also encode zeroTransparent in the lutName

--- a/src/main/java/org/embl/mobie/lib/color/lut/LUTs.java
+++ b/src/main/java/org/embl/mobie/lib/color/lut/LUTs.java
@@ -53,8 +53,7 @@ public class LUTs
 
 	public static boolean isNumeric( String lut )
 	{
-		return lut.contains( BLUE_WHITE_RED )
-				|| lut.contains( VIRIDIS );
+		return lut.contains( BLUE_WHITE_RED ) || lut.contains( VIRIDIS );
 	}
 
 	public static boolean isCategorical( String lut )

--- a/src/main/java/org/embl/mobie/lib/serialize/display/AbstractAnnotationDisplay.java
+++ b/src/main/java/org/embl/mobie/lib/serialize/display/AbstractAnnotationDisplay.java
@@ -130,6 +130,9 @@ public abstract class AbstractAnnotationDisplay< A extends Annotation > extends 
 
 	public ValuePair< Double, Double > getValueLimits()
 	{
+		if ( valueLimits == null )
+			return null;
+
 		return new ValuePair<>( valueLimits[ 0 ], valueLimits[ 1 ] );
 	}
 

--- a/src/main/java/org/embl/mobie/lib/table/saw/TableSawColumnTypes.java
+++ b/src/main/java/org/embl/mobie/lib/table/saw/TableSawColumnTypes.java
@@ -40,11 +40,11 @@ public abstract class TableSawColumnTypes
 		typeToClass = new HashMap<>();
 		typeToClass.put( ColumnType.TEXT, String.class );
 		typeToClass.put( ColumnType.STRING, String.class );
+		typeToClass.put( ColumnType.BOOLEAN, Boolean.class );
 		typeToClass.put( ColumnType.DOUBLE, Double.class );
 		typeToClass.put( ColumnType.INTEGER, Integer.class );
 		typeToClass.put( ColumnType.SHORT, Short.class );
 		typeToClass.put( ColumnType.LONG, Long.class );
-		typeToClass.put( ColumnType.BOOLEAN, Boolean.class );
-		//...
 	}
+
 }

--- a/src/main/java/org/embl/mobie/lib/ui/ColumnColoringModelDialog.java
+++ b/src/main/java/org/embl/mobie/lib/ui/ColumnColoringModelDialog.java
@@ -28,6 +28,7 @@
  */
 package org.embl.mobie.lib.ui;
 
+import ij.IJ;
 import ij.gui.GenericDialog;
 import org.embl.mobie.lib.annotation.Annotation;
 import org.embl.mobie.lib.color.ColoringModel;
@@ -76,18 +77,14 @@ public class ColumnColoringModelDialog< A extends Annotation>
 		if ( paintZeroTransparent )
 			lut += LUTs.ZERO_TRANSPARENT;
 
-		if ( LUTs.isNumeric( lut )  )
+		if ( Number.class.isAssignableFrom( table.columnClass( columnName ) ) )
 		{
 			final Pair< Double, Double > minMax = table.getMinMax( columnName );
 			return ColoringModels.createNumericModel( columnName, lut, minMax, true );
 		}
-		else if ( LUTs.isCategorical( lut ) )
-		{
-			return ColoringModels.createCategoricalModel( columnName, lut, TRANSPARENT );
-		}
 		else
 		{
-			throw new UnsupportedOperationException( "LUT " + lut + " is not supported." );
+			return ColoringModels.createCategoricalModel( columnName, lut, TRANSPARENT );
 		}
 	}
 }

--- a/src/main/java/org/embl/mobie/lib/ui/ColumnColoringModelDialog.java
+++ b/src/main/java/org/embl/mobie/lib/ui/ColumnColoringModelDialog.java
@@ -76,7 +76,7 @@ public class ColumnColoringModelDialog< A extends Annotation>
 		if ( paintZeroTransparent )
 			lut += LUTs.ZERO_TRANSPARENT;
 
-		if ( LUTs.isNumeric( lut ) )
+		if ( LUTs.isNumeric( lut )  )
 		{
 			final Pair< Double, Double > minMax = table.getMinMax( columnName );
 			return ColoringModels.createNumericModel( columnName, lut, minMax, true );

--- a/src/main/java/org/embl/mobie/lib/view/ViewManager.java
+++ b/src/main/java/org/embl/mobie/lib/view/ViewManager.java
@@ -537,7 +537,7 @@ public class ViewManager
 			//
 			String lut = annotationDisplay.getLut();
 
-			if ( LUTs.isCategorical( lut ) )
+			if ( annotationDisplay.getValueLimits() == null )
 			{
 				CategoricalAnnotationColoringModel< Annotation > coloringModel = ColoringModels.createCategoricalModel( annotationDisplay.getColoringColumnName(), lut, LUTs.TRANSPARENT );
 
@@ -563,7 +563,7 @@ public class ViewManager
 
 				annotationDisplay.coloringModel = new MobieColoringModel( coloringModel, annotationDisplay.selectionModel, annotationDisplay.getSelectionColor(), annotationDisplay.getOpacityNotSelected() );
 			}
-			else if ( LUTs.isNumeric( lut ) )
+			else
 			{
 				NumericAnnotationColoringModel< Annotation > coloringModel
 						= ColoringModels.createNumericModel(
@@ -574,10 +574,6 @@ public class ViewManager
 							);
 
 				annotationDisplay.coloringModel = new MobieColoringModel( coloringModel, annotationDisplay.selectionModel, annotationDisplay.getSelectionColor(), annotationDisplay.getOpacityNotSelected() );
-			}
-			else
-			{
-				throw new UnsupportedOperationException("Coloring LUT " + lut + " is not supported.");
 			}
 
 			// show the data


### PR DESCRIPTION
@constantinpape @martinschorb 

Currently we are supporting these LUTs:

```
GLASBEY,
RGBA_COLUMN,
BLUE_WHITE_RED,
VIRIDIS,
```

I think the first two only work for categorial data (i.e. columns of type `String.class`), while I think the last two only work for numerical data. Is that true (sitting in a train with bad internet, thus cannot test right now)?

If it is true I think it may be better to make the color by column GUI a two stage process where

GUI 1: only select the column
GUI 2: only present **_valid_** choices for the LUTs, depending on whether or not `table.columnClass( columnName ) instanceof String`

This would avoid that users can pick invalid combinations.

What do you think?




