### PR TITLE
Add all available channels of OMEZarr.

### DIFF
--- a/src/main/java/org/embl/mobie/lib/hcs/HCSPattern.java
+++ b/src/main/java/org/embl/mobie/lib/hcs/HCSPattern.java
@@ -229,6 +229,7 @@ public enum HCSPattern
 	{
 		switch ( this )
 		{
+			case OMEZarr:
 			case Operetta:
 			case MolecularDevices:
 			case IncuCyteRaw:
@@ -274,7 +275,10 @@ public enum HCSPattern
 	public List< String > getChannels()
 	{
 		if ( hasChannels() )
-			return Collections.singletonList( matcher.group( HCSPattern.CHANNEL ) );
+			if (this == OMEZarr)
+				return channels;
+			else
+				return Collections.singletonList( matcher.group( HCSPattern.CHANNEL ) );
 		else
 			return Collections.singletonList( "1" );
 	}


### PR DESCRIPTION
We encounter a problem with ome-zarr datasets that have more than 1 channel. With the `MoBIE -> Open -> Open HCS Dataset...` command we got only displayed the very first channel. This also was true when we opened MoBIE projects, but this is not surprising since it uses the same code.

This change fixes this issue. All channels are loaded into the HCS dataset for OmeZarr.