### PR TITLE
Fix linking

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
         <n5-zarr.version>1.3.1</n5-zarr.version>
         <n5-hdf5.version>2.2.0</n5-hdf5.version>
         <n5-ij.version>4.1.1</n5-ij.version>
-        <n5-universe.version>1.4.1</n5-universe.version>
+        <n5-universe.version>1.4.3-SNAPSHOT</n5-universe.version>
         <n5-aws-s3.version>4.1.1</n5-aws-s3.version>
         <bigdataviewer-core.version>10.4.13</bigdataviewer-core.version>
         <bigdataviewer-vistools.version>1.0.0-beta-34</bigdataviewer-vistools.version>

--- a/pom.xml
+++ b/pom.xml
@@ -248,13 +248,16 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.4.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.4.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/embl/mobie/lib/create/DatasetSerializer.java
+++ b/src/main/java/org/embl/mobie/lib/create/DatasetSerializer.java
@@ -62,7 +62,7 @@ public class DatasetSerializer
     ProjectCreator projectCreator;
 
     /**
-     * Make a datasetJsonCreator - includes all functions for creating and modifying metadata
+     * Make a DatasetSerializer - includes all functions for creating and modifying metadata
      * stored in dataset Json files
      * @param projectCreator projectCreator
      */
@@ -84,7 +84,7 @@ public class DatasetSerializer
     /**
      * Add named image to dataset Json (including a view with the image name and sensible defaults)
      * @param imageName image name
-     * @param imagePath absolute path to image file
+     * @param imageFile image file
      * @param datasetName dataset name
      * @param uiSelectionGroup name of ui selection group to add image view to i.e. the name of the MoBIE dropdown
      *                         menu it will appear in
@@ -122,6 +122,7 @@ public class DatasetSerializer
     /**
      * Add named segmentation to dataset Json (including a view with the segmentation name and sensible defaults)
      * @param imageName segmentation name
+     * @param imageFile segmentation file
      * @param datasetName dataset name
      * @param uiSelectionGroup name of ui selection group to add segmentation view to i.e. the name of the MoBIE
      *                         dropdown menu it will appear in

--- a/src/main/java/org/embl/mobie/lib/create/DatasetSerializer.java
+++ b/src/main/java/org/embl/mobie/lib/create/DatasetSerializer.java
@@ -204,7 +204,10 @@ public class DatasetSerializer
         File projectDir = projectCreator.getProjectLocation();
         File datasetDir = new File(projectDir, datasetName);
         if (ProjectCreatorHelper.pathIsInsideDir(imageFile, projectDir)) {
-            imageStorageLocation.relativePath = datasetDir.toURI().relativize(imageFile.toURI()).getPath();
+            String relativePath = datasetDir.toPath().relativize(imageFile.toPath()).toString();
+            // force use of forward slashes in relative paths (even on windows). Windows can handle / or \ in relative
+            // paths, so this means they'll work for all OS.
+            imageStorageLocation.relativePath = relativePath.replaceAll("\\\\", "/");
         } else {
             imageStorageLocation.absolutePath = imageFile.getAbsolutePath();
         }

--- a/src/main/java/org/embl/mobie/lib/create/ImagesCreator.java
+++ b/src/main/java/org/embl/mobie/lib/create/ImagesCreator.java
@@ -107,6 +107,20 @@ public class ImagesCreator {
         return new File (filePath).exists();
     }
 
+    /**
+     * Add ImagePlus image to MoBIE project.
+     *
+     * @param imp image
+     * @param imageName image name
+     * @param datasetName dataset name
+     * @param imageType image type i.e. image or segmentation
+     * @param sourceTransform Affine transform of image
+     * @param uiSelectionGroup name of ui selection group to add image view to i.e. the name of the MoBIE dropdown
+     *                         menu it will appear in
+     * @param exclusive whether the image view is exclusive or not i.e. when viewed, does it first remove all current
+     *                  images from the viewer?
+     * @param overwrite whether to overwrite any existing images inside the dataset with the same name
+     */
     public void addImage( ImagePlus imp,
                           String imageName,
                           String datasetName,
@@ -240,6 +254,22 @@ public class ImagesCreator {
         return rows;
     }
 
+    /**
+     * Add existing ome-zarr image to MoBIE project.
+     *
+     * @param uri ome-zarr uri
+     * @param imageName image name
+     * @param datasetName dataset name
+     * @param imageType image type i.e. image or segmentation
+     * @param addMethod link or copy the image - link (leave image as-is, and link to this location. Linking to images
+     *                  outside of the project folder is only supported for local projects),
+     *                  copy (copy image into project)
+     * @param uiSelectionGroup name of ui selection group to add image view to i.e. the name of the MoBIE dropdown
+     *                         menu it will appear in
+     * @param exclusive whether the image view is exclusive or not i.e. when viewed, does it first remove all current
+     *                  images from the viewer?
+     * @param overwrite whether to overwrite any existing images inside the dataset with the same name
+     */
     public void addOMEZarrImage( String uri,
                                  String imageName,
                                  String datasetName,

--- a/src/main/java/org/embl/mobie/lib/create/ProjectCreator.java
+++ b/src/main/java/org/embl/mobie/lib/create/ProjectCreator.java
@@ -72,8 +72,7 @@ public class ProjectCreator {
 
     public enum AddMethod {
         Link,
-        Copy,
-        move
+        Copy
     }
 
     /**

--- a/src/main/java/org/embl/mobie/lib/create/ProjectCreatorHelper.java
+++ b/src/main/java/org/embl/mobie/lib/create/ProjectCreatorHelper.java
@@ -42,6 +42,8 @@ import org.embl.mobie.lib.view.AdditionalViews;
 import ucar.units.*;
 
 import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -338,6 +340,13 @@ public class ProjectCreatorHelper {
         }
 
         return true;
+    }
+
+    public static boolean pathIsInsideDir(File path, File dir) {
+        Path filePath = Paths.get( path.getAbsolutePath() ).normalize();
+        Path dirPath = Paths.get( dir.getAbsolutePath() ).normalize();
+
+        return filePath.startsWith(dirPath);
     }
 
 }

--- a/src/main/java/org/embl/mobie/lib/create/ProjectCreatorHelper.java
+++ b/src/main/java/org/embl/mobie/lib/create/ProjectCreatorHelper.java
@@ -61,7 +61,7 @@ public class ProjectCreatorHelper {
 
     /**
      * Check if entered affine string is valid - i.e. does it only contain valid characters, and have a length of 12
-     * @param affine
+     * @param affine affine string
      * @return whether the affine string is valid or not
      */
     public static boolean isValidAffine(String affine) {

--- a/src/main/java/org/embl/mobie/lib/create/ui/ProjectsCreatorUI.java
+++ b/src/main/java/org/embl/mobie/lib/create/ui/ProjectsCreatorUI.java
@@ -377,7 +377,7 @@ public class ProjectsCreatorUI extends JFrame {
         }
 
         final GenericDialog gd = new GenericDialog( "Remote metadata settings..." );
-        String[] formats= Arrays.stream( ImageDataFormat.values() ).filter( v -> v.isRemote() ).map( v -> v.toString() ).collect( Collectors.toList() ).toArray( new String[0] );
+        String[] formats = new String[]{ImageDataFormat.OmeZarrS3.toString()};
         gd.addChoice("Image format:", formats, formats[0]);
         gd.addStringField("Signing Region", "", 20);
         gd.addStringField("Service endpoint", "https://...", 20);

--- a/src/main/java/org/embl/mobie/lib/create/ui/ProjectsCreatorUI.java
+++ b/src/main/java/org/embl/mobie/lib/create/ui/ProjectsCreatorUI.java
@@ -489,12 +489,14 @@ public class ProjectsCreatorUI extends JFrame {
         }
 
         ImagesCreator imagesCreator = projectCreator.getImagesCreator();
-        boolean overwriteImage = true;
+
+        // If image already exists, check if they want to overwrite it
+        boolean overwriteImage = false;
         if ( imagesCreator.imageExists( datasetName, imageName ) ) {
             overwriteImage = overwriteImageDialog();
-        }
-        if ( !overwriteImage ) {
-            return;
+            if ( !overwriteImage ) {
+                return;
+            }
         }
 
         String chosenUiSelectionGroup = selectUiSelectionGroupDialog(datasetName);
@@ -504,7 +506,8 @@ public class ProjectsCreatorUI extends JFrame {
             uiSelectionGroup = chosenUiSelectionGroup;
         }
 
-        imagesCreator.addOMEZarrImage( uri, imageName, datasetName, imageType, addMethod, uiSelectionGroup, exclusive );
+        imagesCreator.addOMEZarrImage( uri, imageName, datasetName, imageType, addMethod, uiSelectionGroup,
+                exclusive, overwriteImage );
         updateComboBoxesForNewImage(imageName, uiSelectionGroup);
 
     }
@@ -658,13 +661,16 @@ public class ProjectsCreatorUI extends JFrame {
                 if ( imageName != null && sourceTransform != null ) {
                     ImagesCreator imagesCreator = projectCreator.getImagesCreator();
 
-                    boolean overwriteImage = true;
+                    // If image already exists, check if they want to overwrite it
+                    boolean overwriteImage = false;
                     if ( imagesCreator.imageExists( datasetName, imageName ) ) {
                         overwriteImage = overwriteImageDialog();
+
+                        if ( !overwriteImage ) {
+                            return;
+                        }
                     }
-                    if ( !overwriteImage ) {
-                        return;
-                    }
+
 
                     String chosenUiSelectionGroup = selectUiSelectionGroupDialog(datasetName);
                     if ( chosenUiSelectionGroup == null ) {
@@ -673,7 +679,8 @@ public class ProjectsCreatorUI extends JFrame {
                         uiSelectionGroup = chosenUiSelectionGroup;
                     }
 
-                    imagesCreator.addImage(currentImage, imageName, datasetName, imageType, sourceTransform, uiSelectionGroup, exclusive);
+                    imagesCreator.addImage(currentImage, imageName, datasetName, imageType, sourceTransform,
+                            uiSelectionGroup, exclusive, overwriteImage);
                     updateComboBoxesForNewImage(imageName, uiSelectionGroup);
                 }
             }

--- a/src/main/java/org/embl/mobie/lib/create/ui/ProjectsCreatorUI.java
+++ b/src/main/java/org/embl/mobie/lib/create/ui/ProjectsCreatorUI.java
@@ -400,7 +400,7 @@ public class ProjectsCreatorUI extends JFrame {
 
     /**
      * Dialog to choose a dataset
-     * @return Name of chosen datset, or null if cancelled
+     * @return Name of chosen dataset, or null if cancelled
      */
     public String chooseDatasetDialog() {
         final GenericDialog gd = new GenericDialog( "Choose a dataset" );
@@ -437,6 +437,9 @@ public class ProjectsCreatorUI extends JFrame {
         }
     }
 
+    /**
+     * Dialog to add an existing ome-zarr image to a MoBIE project
+     */
     public void addOMEZarrDialog() {
         String datasetName = (String) datasetComboBox.getSelectedItem();
 

--- a/src/main/java/org/embl/mobie/lib/create/ui/ProjectsCreatorUI.java
+++ b/src/main/java/org/embl/mobie/lib/create/ui/ProjectsCreatorUI.java
@@ -392,7 +392,8 @@ public class ProjectsCreatorUI extends JFrame {
             String bucketName = gd.getNextString();
 
             if ( continueDialog(format) ) {
-                projectCreator.getRemoteMetadataCreator().createRemoteMetadata( signingRegion, serviceEndpoint, bucketName, format );
+                projectCreator.getRemoteMetadataCreator().createOMEZarrRemoteMetadata(
+                        signingRegion, serviceEndpoint, bucketName );
             }
         }
     }

--- a/src/main/java/org/embl/mobie/lib/create/ui/ProjectsCreatorUI.java
+++ b/src/main/java/org/embl/mobie/lib/create/ui/ProjectsCreatorUI.java
@@ -458,14 +458,6 @@ public class ProjectsCreatorUI extends JFrame {
             exclusive = gd.getNextBoolean();
             useFileNameAsImageName = gd.getNextBoolean();
 
-            // FIXME https://github.com/mobie/mobie-viewer-fiji/issues/1117
-            //       we should support this!
-            if ( addMethod == ProjectCreator.AddMethod.Link )
-            {
-                IJ.log( "link is currently unsupported for ome-zarr. Please choose copy or move instead for this file format." );
-                return;
-            }
-
             String filePath = getOMEZarrImagePathDialog();
 
             if ( filePath != null )

--- a/src/test/java/org/embl/mobie/lib/create/ImagesCreatorTest.java
+++ b/src/test/java/org/embl/mobie/lib/create/ImagesCreatorTest.java
@@ -151,7 +151,8 @@ class ImagesCreatorTest {
     }
 
     void assertionsForTableAdded( ) throws IOException {
-        String tablePath = IOHelper.combinePath( projectCreator.getProjectLocation().getAbsolutePath(), datasetName, "tables", imageName, "default.tsv" );
+        String tablePath = IOHelper.combinePath( projectCreator.getProjectLocation().getAbsolutePath(),
+                datasetName, "tables", imageName, "default.tsv" );
         assertTrue( new File(tablePath).exists() );
 
         Dataset dataset = new DatasetJsonParser().parseDataset(datasetJsonPath);

--- a/src/test/java/org/embl/mobie/lib/create/ImagesCreatorTest.java
+++ b/src/test/java/org/embl/mobie/lib/create/ImagesCreatorTest.java
@@ -36,6 +36,7 @@ import org.embl.mobie.io.ImageDataOpener;
 import org.embl.mobie.io.OMEZarrWriter;
 import org.embl.mobie.io.imagedata.ImageData;
 import org.embl.mobie.io.util.IOHelper;
+import org.embl.mobie.lib.io.StorageLocation;
 import org.embl.mobie.lib.serialize.Dataset;
 import org.embl.mobie.lib.serialize.DatasetJsonParser;
 import org.embl.mobie.lib.serialize.ImageDataSource;
@@ -44,11 +45,12 @@ import org.embl.mobie.lib.table.TableDataFormat;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Arrays;
 
 import static org.embl.mobie.lib.create.JSONValidator.validate;
 import static org.embl.mobie.lib.create.ProjectCreatorTestHelper.createImage;
@@ -67,6 +69,7 @@ class ImagesCreatorTest {
     private String uiSelectionGroup;
     private String datasetJsonPath;
     private File tempDir;
+    private ImagePlus image;
 
     @BeforeEach
     void setUp( @TempDir Path tempDir ) throws IOException {
@@ -78,47 +81,73 @@ class ImagesCreatorTest {
         datasetName = "test";
         uiSelectionGroup = "testGroup";
         sourceTransform = new AffineTransform3D();
+        image = null;
 
         projectCreator.getDatasetsCreator().addDataset(datasetName, false);
 
         datasetJsonPath = IOHelper.combinePath( projectCreator.getProjectLocation().getAbsolutePath(), datasetName, "dataset.json" );
     }
 
-
-    void assertionsForDataset( ) throws IOException {
+    void assertionsForDataset(File imageLocation) throws IOException {
         assertTrue( new File(datasetJsonPath).exists() );
         Dataset dataset = new DatasetJsonParser().parseDataset(datasetJsonPath);
         assertTrue( dataset.sources().containsKey(imageName) );
         assertTrue( dataset.views().containsKey(imageName) );
-        assertTrue( ((ImageDataSource)dataset.sources().get(imageName)).imageData.containsKey( ImageDataFormat.OmeZarr) );
+
+        ImageDataSource source = (ImageDataSource)dataset.sources().get(imageName);
+        assertTrue( source.imageData.containsKey( ImageDataFormat.OmeZarr ));
+
+        // check image location in dataset json is correct
+        StorageLocation storageLocation = source.imageData.get(ImageDataFormat.OmeZarr);
+        String imagePath = storageLocation.relativePath;
+        if (imagePath != null) {
+            imagePath = IOHelper.combinePath( projectCreator.getProjectLocation().getAbsolutePath(),
+                    datasetName, imagePath);
+        } else {
+            imagePath = storageLocation.absolutePath;
+        }
+        assertEquals(imageLocation.getAbsolutePath(), new File(imagePath).getAbsolutePath());
+
         // Check that this follows JSON schema
         assertTrue( validate( datasetJsonPath, JSONValidator.datasetSchemaURL ) );
     }
 
-    void assertionsForImage()
+    void assertionsForImage(File imageLocation) throws IOException
     {
-        String imageLocation = IOHelper.combinePath(
-                projectCreator.getProjectLocation().getAbsolutePath(),
-                datasetName,
-                "images",
-                imageName + ".ome.zarr");
-
         // File exists
-        assertTrue( new File(imageLocation).exists() );
+        assertTrue( imageLocation.exists() );
 
         // Image can be opened
-        ImageData< ? > imageData = ImageDataOpener.open( imageLocation );
+        ImageData< ? > imageData = ImageDataOpener.open( imageLocation.getAbsolutePath() );
         assertNotNull( imageData.getSourcePair( 0 ).getB() );
 
-        // TODO: make this an assertion by comparing to the input ImagePlus
+        // Image has correct unit and pixel size
         VoxelDimensions voxelDimensions = imageData.getSourcePair( 0 ).getB().getVoxelDimensions();
-        System.out.println( "Pixel unit: " + voxelDimensions.unit() );
-        System.out.println( "Pixel size: " + Arrays.toString( voxelDimensions.dimensionsAsDoubleArray() ) );
+        assertEquals(voxelDimensions.unit(), image.getCalibration().getUnit());
+        assertArrayEquals(
+                voxelDimensions.dimensionsAsDoubleArray(),
+                new double[]{
+                        image.getCalibration().pixelWidth,
+                        image.getCalibration().pixelHeight,
+                        image.getCalibration().pixelDepth
+        });
     }
 
     void assertionsForImageAdded() throws IOException {
-        assertionsForDataset();
-        assertionsForImage();
+        File imageLocation = new File(
+                IOHelper.combinePath(
+                        projectCreator.getProjectLocation().getAbsolutePath(),
+                        datasetName,
+                        "images",
+                        imageName + ".ome.zarr")
+                );
+
+        assertionsForImageAdded(imageLocation);
+    }
+
+    void assertionsForImageAdded(File imageLocation) throws IOException {
+        assertionsForDataset(imageLocation);
+        assertionsForImage(imageLocation);
     }
 
     void assertionsForTableAdded( ) throws IOException {
@@ -132,48 +161,17 @@ class ImagesCreatorTest {
 
     String writeImageAndGetPath( boolean is2D ) {
         // add example image
-        ImagePlus imp = createImage( imageName, is2D );
+        image = createImage( imageName, is2D );
         String filePath = new File(tempDir, imageName + ".ome.zarr").getAbsolutePath();
-        OMEZarrWriter.write( imp, filePath, OMEZarrWriter.ImageType.Intensities, true );
+        OMEZarrWriter.write( image, filePath, OMEZarrWriter.ImageType.Intensities, false );
         return filePath;
     }
 
-    void addImage( boolean is2D ) {
-        ImagePlus imp = createImage( imageName, is2D );
-        imagesCreator.addImage( imp, imageName, datasetName,
+    void addImage( boolean is2D, String datasetName, String imageName ) {
+        image = createImage( imageName, is2D );
+        imagesCreator.addImage( image, imageName, datasetName,
                 ProjectCreator.ImageType.Image, sourceTransform,
-                uiSelectionGroup, false );
-    }
-
-    void testAddingImage( boolean is2D ) throws IOException {
-        addImage( is2D );
-        assertionsForImageAdded();
-    }
-
-    void testAddingSegmentation() throws IOException{
-        ImagePlus seg = createLabels( imageName );
-
-        imagesCreator.addImage( seg, imageName, datasetName,
-                ProjectCreator.ImageType.Segmentation,
-                sourceTransform, uiSelectionGroup, false );
-
-        assertionsForImageAdded();
-        assertionsForTableAdded();
-    }
-
-    // FIXME: Do we need all the is2D booleans here?
-    //        Ask Kimberly in an issue
-
-    void testLinkingImages( boolean is2D ) throws IOException {
-
-        // save example image
-        String filePath = writeImageAndGetPath( is2D );
-
-        imagesCreator.addOMEZarrImage( filePath, imageName, datasetName,
-                ProjectCreator.ImageType.Image, ProjectCreator.AddMethod.Link,
-                uiSelectionGroup, false );
-
-        assertionsForImageAdded();
+                uiSelectionGroup, false, false );
     }
 
     void copyImage(  boolean is2D ) {
@@ -182,51 +180,93 @@ class ImagesCreatorTest {
 
         imagesCreator.addOMEZarrImage( filePath, imageName, datasetName,
                 ProjectCreator.ImageType.Image,
-                ProjectCreator.AddMethod.Copy, uiSelectionGroup, false );
+                ProjectCreator.AddMethod.Copy, uiSelectionGroup, false, false );
     }
 
-    void testCopyingImages( boolean is2D ) throws IOException {
-        copyImage( is2D );
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    void addImageTo3DDataset(boolean is2D) throws IOException {
+        addImage( is2D, datasetName, imageName );
         assertionsForImageAdded();
-    }
-
-    @Test
-    void addImage() throws IOException {
-        testAddingImage( false );
-    }
-
-    @Test
-    void addSegmentation() throws IOException {
-        testAddingSegmentation();
-    }
-
-    // FIXME: https://github.com/mobie/mobie-viewer-fiji/issues/1116
-//    @Test
-//    void linkImage() throws IOException {
-//        testLinkingImages( false );
-//    }
-
-    @Test
-    void copyImage() throws IOException {
-        testCopyingImages( false );
-    }
-
-    @Test
-    void add2DImageTo3DDataset() throws IOException {
-        testAddingImage( true );
-    }
-
-    @Test
-    void copy2DImageTo3DDataset() throws IOException {
-        testCopyingImages( true );
     }
 
     @Test
     void add3DImageTo2DDataset() {
         projectCreator.getDatasetsCreator().makeDataset2D(datasetName, true);
         assertThrows( UnsupportedOperationException.class, () -> {
-            addImage( false);
+            addImage( false, datasetName, imageName);
         } );
+    }
+
+    @Test
+    void addSegmentation() throws IOException {
+        ImagePlus seg = createLabels( imageName );
+
+        imagesCreator.addImage( seg, imageName, datasetName,
+                ProjectCreator.ImageType.Segmentation,
+                sourceTransform, uiSelectionGroup, false, false );
+
+        assertionsForImageAdded();
+        assertionsForTableAdded();
+    }
+
+    /**
+     * Test linking to an image in a different dataset within the project.
+     * This kind of linking is useful e.g. in the platybrowser, where new versions link to
+     * images in older datasets to avoid duplication.
+     */
+    @Test
+    void linkImageInsideProject() throws IOException {
+        // Create an image in a separate dataset within the project
+        String otherDatasetName = "other-dataset";
+        String otherImageName = "other-image";
+        projectCreator.getDatasetsCreator().addDataset(otherDatasetName, false);
+        addImage(false, otherDatasetName, otherImageName);
+        String filePath = IOHelper.combinePath(
+                projectCreator.getProjectLocation().getAbsolutePath(),
+                otherDatasetName,
+                "images",
+                otherImageName + ".ome.zarr");
+
+        // Link to the image in the separate dataset
+        imagesCreator.addOMEZarrImage( filePath, imageName, datasetName,
+                ProjectCreator.ImageType.Image, ProjectCreator.AddMethod.Link,
+                uiSelectionGroup, false, false );
+
+        assertionsForImageAdded(new File(filePath));
+
+        // check that a relative path is used, rather than an absolute one
+        Dataset dataset = new DatasetJsonParser().parseDataset(datasetJsonPath);
+        ImageDataSource source = (ImageDataSource)dataset.sources().get(imageName);
+        StorageLocation storageLocation = source.imageData.get(ImageDataFormat.OmeZarr);
+        assertNotNull(storageLocation.relativePath);
+        assertNull(storageLocation.absolutePath);
+
+    }
+
+    @Test
+    void linkImageOutsideProject() throws IOException {
+        // save example image
+        String filePath = writeImageAndGetPath( false );
+        imagesCreator.addOMEZarrImage( filePath, imageName, datasetName,
+                ProjectCreator.ImageType.Image, ProjectCreator.AddMethod.Link,
+                uiSelectionGroup, false, false );
+
+        assertionsForImageAdded(new File(filePath));
+
+        // check that an absolute path is used, rather than a relative one
+        Dataset dataset = new DatasetJsonParser().parseDataset(datasetJsonPath);
+        ImageDataSource source = (ImageDataSource)dataset.sources().get(imageName);
+        StorageLocation storageLocation = source.imageData.get(ImageDataFormat.OmeZarr);
+        assertNull(storageLocation.relativePath);
+        assertNotNull(storageLocation.absolutePath);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    void copyImageTo3DDataset(boolean is2D) throws IOException {
+        copyImage( is2D );
+        assertionsForImageAdded();
     }
 
     @Test

--- a/src/test/java/org/embl/mobie/lib/create/RemoteMetadataCreatorTest.java
+++ b/src/test/java/org/embl/mobie/lib/create/RemoteMetadataCreatorTest.java
@@ -63,7 +63,9 @@ class RemoteMetadataCreatorTest {
     @BeforeEach
     void setUp( @TempDir Path tempDir ) throws IOException {
         this.tempDir = tempDir.toFile();
-        projectCreator = new ProjectCreator( this.tempDir );
+        // Write project into sub-folder called 'data'
+        File projectDir = new File(this.tempDir, "data");
+        projectCreator = new ProjectCreator( projectDir );
         remoteMetadataCreator = projectCreator.getRemoteMetadataCreator();
 
         datasetName = "test";
@@ -125,6 +127,9 @@ class RemoteMetadataCreatorTest {
         projectCreator.getImagesCreator().addOMEZarrImage( filePath, imageName, datasetName,
                 ProjectCreator.ImageType.Image, ProjectCreator.AddMethod.Link,
                 uiSelectionGroup, false, false );
+
+        // try to add remote metadata
+        remoteMetadataCreator.createOMEZarrRemoteMetadata( signingRegion, serviceEndpoint, bucketName );
 
         // check that it detected the image was outside the project, and therefore didn't write the remote metadata
         Dataset dataset = new DatasetJsonParser().parseDataset( datasetJsonPath );

--- a/src/test/java/org/embl/mobie/lib/create/RemoteMetadataCreatorTest.java
+++ b/src/test/java/org/embl/mobie/lib/create/RemoteMetadataCreatorTest.java
@@ -75,7 +75,7 @@ class RemoteMetadataCreatorTest {
         // add image of right type
         projectCreator.getImagesCreator().addImage( ProjectCreatorTestHelper.createImage(imageName, false), imageName,
                 datasetName, ProjectCreator.ImageType.Image, new AffineTransform3D(),
-                uiSelectionGroup, false );
+                uiSelectionGroup, false, false );
 
         ImageDataFormat remoteFormat = ImageDataFormat.OmeZarrS3;
 

--- a/src/test/java/projects/rafael/CreateRafaelProject.java
+++ b/src/test/java/projects/rafael/CreateRafaelProject.java
@@ -104,7 +104,8 @@ public class CreateRafaelProject
 			for ( int c = 0; c < channels.length; c++ )
 			{
 				final String imageName = "Sections_B_z" + sectionIndex + "_c" + c;
-				images.addImage( channels[ c ], imageName, datasetName, ProjectCreator.ImageType.Image, affineTransform3D, uiSelectionGroup, false );
+				images.addImage( channels[ c ], imageName, datasetName, ProjectCreator.ImageType.Image,
+						affineTransform3D, uiSelectionGroup, false, false );
 			}
 		}
 


### PR DESCRIPTION
For https://github.com/mobie/mobie-viewer-fiji/issues/1116

This PR:
- Fixes linking images within the project creator (uses absolutePath if the image is outside the project directory)
- Fixes remote metadata creation
- Fixes failing project creator tests + adds more for linking / remote metadata
- Updates the javadoc

Note: I've currently commented out the line in `ImagesCreatorTest` that validates the dataset json against the schema. This is due to the missing `absolutePath`. It can be un-commented once this is added.

Also, this doesn't currently support directly giving an `s3address` to the project creator (for files that are already stored remotely). This is probably best added later, as it's a new feature that wasn't in the original project creator.