### PR TITLE
fix: correct path resolution with root directory handling

### DIFF
--- a/src/main/java/org/embl/mobie/lib/data/ImageGridSources.java
+++ b/src/main/java/org/embl/mobie/lib/data/ImageGridSources.java
@@ -133,7 +133,7 @@ public class ImageGridSources
 			for ( int rowIndex = 0; rowIndex < numRows; rowIndex++ )
 			{
 				String fileName = table.getString( rowIndex, imageColumn );
-				String folder = table.getString( rowIndex, folderColumn );
+				String folder = root != null ? root : table.getString( rowIndex, folderColumn );
 				String path = IOHelper.combinePath( folder, fileName );
 				String imageName = createImageName( channelIndex, fileName );
 				nameToFullPath.put( imageName, applyPathMapping( pathMapping, path ) );


### PR DESCRIPTION
- Fixed the logic for resolving paths by using the root directory when it's not null.
- If the root directory is null, the path is now resolved using the Cellprofiler column.