### PR TITLE
Fix null pointer exception in ImageCreator

### DIFF
--- a/src/main/java/org/embl/mobie/lib/create/ImagesCreator.java
+++ b/src/main/java/org/embl/mobie/lib/create/ImagesCreator.java
@@ -290,7 +290,7 @@ public class ImagesCreator {
         File imagesDirectory = new File( getDefaultLocalImageDirPath( datasetName ) );
 
         ImageDataFormat imageDataFormat = ImageDataFormat.fromPath( uri );
-        imageDataFormat.setS3SecretAndAccessKey( MoBIE.getInstance().getSettings().values.getS3AccessAndSecretKey() );
+        addS3keys( imageDataFormat );
         ImageData< ? > imageData = ImageDataOpener.open(
                 uri,
                 imageDataFormat,


### PR DESCRIPTION
For https://github.com/mobie/mobie-viewer-fiji/issues/1218

This should fix the reported `NullPointerException` + means all the project creator tests now pass. There is still a long deprecation warning printed out (see below), but this doesn't seem to stop anything working correctly.  As far as I can tell this is to do with [the `AmazonS3ClientBuilder.standard();` line in MoBIE](https://github.com/mobie/mobie-viewer-fiji/blob/main/src/main/java/org/embl/mobie/MoBIE.java#L94), rather than the project creator code itself.

```
15:43:38.782 [Thread-21] WARN com.amazonaws.util.VersionInfoUtils - The AWS SDK for Java 1.x entered maintenance mode starting July 31, 2024 and will reach end of support on December 31, 2025. For more information, see https://aws.amazon.com/blogs/developer/the-aws-sdk-for-java-1-x-is-in-maintenance-mode-effective-july-31-2024/
You can print where on the file system the AWS SDK for Java 1.x core runtime is located by setting the AWS_JAVA_V1_PRINT_LOCATION environment variable or aws.java.v1.printLocation system property to 'true'.
This message can be disabled by setting the AWS_JAVA_V1_DISABLE_DEPRECATION_ANNOUNCEMENT environment variable or aws.java.v1.disableDeprecationAnnouncement system property to 'true'.
The AWS SDK for Java 1.x is being used here:
at java.lang.Thread.getStackTrace(Thread.java:1564)
at com.amazonaws.util.VersionInfoUtils.printDeprecationAnnouncement(VersionInfoUtils.java:81)
at com.amazonaws.util.VersionInfoUtils.<clinit>(VersionInfoUtils.java:59)
at com.amazonaws.internal.EC2ResourceFetcher.<clinit>(EC2ResourceFetcher.java:44)
at com.amazonaws.auth.InstanceMetadataServiceCredentialsFetcher.<init>(InstanceMetadataServiceCredentialsFetcher.java:38)
at com.amazonaws.auth.InstanceProfileCredentialsProvider.<init>(InstanceProfileCredentialsProvider.java:111)
at com.amazonaws.auth.InstanceProfileCredentialsProvider.<init>(InstanceProfileCredentialsProvider.java:91)
at com.amazonaws.auth.InstanceProfileCredentialsProvider.<init>(InstanceProfileCredentialsProvider.java:75)
at com.amazonaws.auth.InstanceProfileCredentialsProvider.<clinit>(InstanceProfileCredentialsProvider.java:58)
at com.amazonaws.auth.EC2ContainerCredentialsProviderWrapper.initializeProvider(EC2ContainerCredentialsProviderWrapper.java:66)
at com.amazonaws.auth.EC2ContainerCredentialsProviderWrapper.<init>(EC2ContainerCredentialsProviderWrapper.java:55)
at com.amazonaws.auth.DefaultAWSCredentialsProviderChain.<init>(DefaultAWSCredentialsProviderChain.java:60)
at com.amazonaws.auth.DefaultAWSCredentialsProviderChain.<clinit>(DefaultAWSCredentialsProviderChain.java:54)
at com.amazonaws.services.s3.AmazonS3ClientBuilder.standard(AmazonS3ClientBuilder.java:46)
at org.embl.mobie.MoBIE.lambda$static$0(MoBIE.java:94)
at java.lang.Thread.run(Thread.java:750)

```