### PR TITLE
Add numericAnnotation data source type

### DIFF
--- a/src/main/java/org/embl/mobie/MoBIE.java
+++ b/src/main/java/org/embl/mobie/MoBIE.java
@@ -746,6 +746,13 @@ public class MoBIE
 			regionTableSource.table = TableOpener.open( tableLocation, tableFormat );
 			DataStore.addRawData( regionTableSource );
 		}
+		else if ( dataSource instanceof NumericAnnotationDataSource )
+		{
+			// NumericAnnotationDataSources are expanded after all base sources
+			// have been initialised (see ViewManager.initData()).
+			// The base annotation image must already be in DataStore
+			// before the NumericAnnotationImage wrapper can be created.
+		}
 
 		if ( log != null )
 			IJ.log( log + dataSource.getName() );

--- a/src/main/java/org/embl/mobie/lib/serialize/DataSourceMapAdapter.java
+++ b/src/main/java/org/embl/mobie/lib/serialize/DataSourceMapAdapter.java
@@ -47,6 +47,8 @@ public class DataSourceMapAdapter implements JsonSerializer< Map< String, DataSo
 		classToName.put( RegionTableSource.class.getName(), "regions");
 		nameToClass.put("spots", SpotDataSource.class);
 		classToName.put( SpotDataSource.class.getName(), "spots");
+		nameToClass.put("numericAnnotation", NumericAnnotationDataSource.class);
+		classToName.put( NumericAnnotationDataSource.class.getName(), "numericAnnotation");
 	}
 
 	@Override

--- a/src/main/java/org/embl/mobie/lib/serialize/NumericAnnotationDataSource.java
+++ b/src/main/java/org/embl/mobie/lib/serialize/NumericAnnotationDataSource.java
@@ -1,0 +1,78 @@
+/*-
+ * #%L
+ * Fiji viewer for MoBIE projects
+ * %%
+ * Copyright (C) 2018 - 2024 EMBL
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.embl.mobie.lib.serialize;
+
+/**
+ * Declares a derived image source that wraps an annotation (segmentation/spot) label image
+ * and maps each pixel to a numeric value from a table column.
+ * <p>
+ * In dataset.json, this creates an {@code Image<DoubleType>} where each pixel belonging to
+ * an annotation carries that annotation's value for the specified column. Background pixels
+ * are zero.
+ * <p>
+ * Example JSON:
+ * <pre>{@code
+ * "nuclei-mean_intensity": {
+ *   "numericAnnotation": {
+ *     "annotationSource": "nuclei",
+ *     "column": "mean_intensity"
+ *   }
+ * }
+ * }</pre>
+ * <p>
+ * The referenced {@code annotationSource} must be loaded before this source is expanded.
+ * Expansion happens after all base sources have been initialised (in {@code ViewManager.initData()}).
+ */
+public class NumericAnnotationDataSource extends AbstractDataSource
+{
+	/**
+	 * Name of an existing annotation (segmentation/spot) source
+	 * whose label image provides the pixel mask.
+	 */
+	public String annotationSource;
+
+	/**
+	 * Name of the numeric column in the annotation source's table.
+	 * Each pixel belonging to an annotation will carry that annotation's
+	 * value from this column.
+	 */
+	public String column;
+
+	public NumericAnnotationDataSource()
+	{
+		super();
+	}
+
+	public NumericAnnotationDataSource( String name, String annotationSource, String column )
+	{
+		super( name );
+		this.annotationSource = annotationSource;
+		this.column = column;
+	}
+}

--- a/src/main/java/org/embl/mobie/lib/serialize/NumericAnnotationDataSource.java
+++ b/src/main/java/org/embl/mobie/lib/serialize/NumericAnnotationDataSource.java
@@ -46,8 +46,27 @@ package org.embl.mobie.lib.serialize;
  * }
  * }</pre>
  * <p>
- * The referenced {@code annotationSource} must be loaded before this source is expanded.
- * Expansion happens after all base sources have been initialised (in {@code ViewManager.initData()}).
+ * The referenced {@code annotationSource} is initialised automatically by
+ * {@code ViewManager.initData()} (which now also loads the base annotation sources of
+ * numeric annotations before expansion), so it does not need to be listed in the view
+ * itself. Expansion happens after all base sources have been initialised.
+ *
+ * <p>
+ * Sample view (view.json) that renders the numeric annotation as an image layer:
+ * <pre>{@code
+ * {
+ *   "sourceDisplays": [
+ *     { "segmentationDisplay": { "sources": [ "nuclei" ] } },
+ *     {
+ *       "imageDisplay": {
+ *         "sources": [ "nuclei-anchor_z" ],
+ *         "color": "viridis",
+ *         "contrastLimits": [ 0, 200 ]
+ *       }
+ *     }
+ *   ]
+ * }
+ * }</pre>
  */
 public class NumericAnnotationDataSource extends AbstractDataSource
 {

--- a/src/main/java/org/embl/mobie/lib/view/ViewManager.java
+++ b/src/main/java/org/embl/mobie/lib/view/ViewManager.java
@@ -54,6 +54,7 @@ import org.embl.mobie.lib.image.*;
 import org.embl.mobie.lib.plot.ScatterPlotSettings;
 import org.embl.mobie.lib.plot.ScatterPlotView;
 import org.embl.mobie.lib.serialize.DataSource;
+import org.embl.mobie.lib.serialize.NumericAnnotationDataSource;
 import org.embl.mobie.lib.serialize.View;
 import org.embl.mobie.lib.serialize.display.*;
 import org.embl.mobie.lib.serialize.transformation.*;
@@ -415,6 +416,23 @@ public class ViewManager
 
 		if ( ! dataSources.isEmpty() )
 			moBIE.initDataSources( dataSources );
+
+		// Expand NumericAnnotationDataSources into NumericAnnotationImages.
+		// This must run after initDataSources() so that the base annotation
+		// images are guaranteed to be in DataStore.
+		for ( DataSource dataSource : dataSources )
+		{
+			if ( dataSource instanceof NumericAnnotationDataSource )
+			{
+				NumericAnnotationDataSource nas = ( NumericAnnotationDataSource ) dataSource;
+				Image< ? > baseImage = DataStore.getImage( nas.annotationSource );
+				@SuppressWarnings( { "unchecked", "rawtypes" } )
+				final NumericAnnotationImage numericImage = new NumericAnnotationImage(
+						( Image ) baseImage,
+						nas.column );
+				DataStore.addImage( numericImage );
+			}
+		}
 
 		// transform images
 		// this may create new images with new names

--- a/src/main/java/org/embl/mobie/lib/view/ViewManager.java
+++ b/src/main/java/org/embl/mobie/lib/view/ViewManager.java
@@ -381,6 +381,21 @@ public class ViewManager
 		// by a display or transformation)
 		List< DataSource > dataSources = moBIE.getDataSources( sourceToTransformOrDisplay.keySet() );
 
+		// Numeric annotation sources reference a base annotation source
+		// (e.g. a segmentation) via `annotationSource`. That base source
+		// may not be listed directly in the view, but it must be initialised
+		// before the numeric annotation image can be built (see expansion
+		// below). Include it here so the view loads it automatically.
+		final Set< String > baseAnnotationSourceNames = new HashSet<>();
+		for ( DataSource dataSource : dataSources )
+			if ( dataSource instanceof NumericAnnotationDataSource )
+				baseAnnotationSourceNames.add( ( ( NumericAnnotationDataSource ) dataSource ).annotationSource );
+
+		baseAnnotationSourceNames.removeAll( sourceToTransformOrDisplay.keySet() );
+
+		if ( ! baseAnnotationSourceNames.isEmpty() )
+			dataSources.addAll( moBIE.getDataSources( baseAnnotationSourceNames ) );
+
 		// if a view is created on the fly in a running project, e.g. due to an image registration
 		// the data sources may already be present and thus do not need to be instantiated
 		// HOWEVER: the issue here is that then an image may exist already and a transformation is applied twice (see below)


### PR DESCRIPTION
## Summary

Adds a new `numericAnnotation` data source type to `dataset.json` that dynamically generates an `Image<DoubleType>` from an annotation (segmentation/spot) label image plus a table column. Each pixel belonging to an annotation carries that annotation's numeric value for the column; background pixels are zero.

The resulting source behaves like any standard intensity image — color (LUT), contrast, invert, opacity, and blending all work identically through the existing `ImageDisplay`/`ImageSliceView` path.

## Changes

- **`NumericAnnotationDataSource`** (new, `lib/serialize/`): fields `annotationSource` + `column`.
- **`DataSourceMapAdapter`**: registers the `"numericAnnotation"` type key.
- **`MoBIE.initDataSource()`**: no-op branch (deferred handling — the base image isn't ready yet when sources load in parallel).
- **`ViewManager.initData()`**:
  - includes each `annotationSource` in the set of sources to initialise, so a view can reference a numeric annotation without also listing its base segmentation;
  - after all base sources load, wraps the base annotation image in `NumericAnnotationImage` and registers it via `DataStore.addImage`.

## Example

dataset.json:

```json
{
  "sources": {
    "nuclei": {
      "segmentation": {
        "imageData": { "0": { "relativePath": "images/nuclei" } },
        "tableData": { "tsv": { "relativePath": "tables/default.tsv" } }
      }
    },
    "nuclei-anchor_z": {
      "numericAnnotation": { "annotationSource": "nuclei", "column": "anchor_z" }
    }
  },
  "views": {
    "default": {
      "sourceDisplays": [
        { "segmentationDisplay": { "sources": ["nuclei"] } },
        { "imageDisplay": { "sources": ["nuclei-anchor_z"], "contrastLimits": [0, 280] } }
      ]
    }
  }
}
```

## Testing

Verified locally against a project with a nuclei segmentation and a table column (`anchor_z`): the numeric annotation layer loads as an image source, renders correctly, and supports recolor/contrast like any other intensity image.