### PR TITLE
Persistent disk-backed mesh cache for segment 3D rendering

### DIFF
--- a/src/main/java/org/embl/mobie/lib/table/TableView.java
+++ b/src/main/java/org/embl/mobie/lib/table/TableView.java
@@ -38,6 +38,7 @@ import bdv.viewer.Source;
 import org.embl.mobie.lib.data.DataStore;
 import org.embl.mobie.lib.util.MoBIEHelper;
 import org.embl.mobie.lib.volume.MeshCache;
+import org.embl.mobie.lib.volume.SegmentMeshCacher;
 import org.embl.mobie.lib.image.Image;
 import org.embl.mobie.lib.image.NumericAnnotationImage;
 import org.embl.mobie.lib.serialize.View;
@@ -339,29 +340,7 @@ public class TableView< A extends Annotation > implements SelectionListener< A >
 		try
 		{
 			final SegmentationDisplay segmentationDisplay = ( SegmentationDisplay ) display;
-			if ( segmentationDisplay.segmentVolumeViewer == null )
-			{
-				IJ.showMessage( "The 3D segment viewer is not initialised for this table." );
-				return;
-			}
-
-			segmentationDisplay.segmentVolumeViewer.setVoxelSpacing( new double[]{ spacing, spacing, spacing } );
-			segmentationDisplay.segmentVolumeViewer.configureMeshCache( display.getName(), MoBIEHelper.getMeshCacheDir() );
-
-			Collection segments = tableModel.annotations();
-			if ( segments.isEmpty() )
-				segments = selectionModel.getSelected();
-			if ( segments.isEmpty() )
-			{
-				IJ.showMessage( "No segments to cache." );
-				return;
-			}
-
-			final int cachedBefore = segmentationDisplay.segmentVolumeViewer.getMeshCache().size();
-			IJ.showStatus( "Caching " + segments.size() + " segment meshes at " + formatSpacing( spacing ) + " um ..." );
-			segmentationDisplay.segmentVolumeViewer.preRenderSegments( segments );
-			final int newlyCached = segmentationDisplay.segmentVolumeViewer.getMeshCache().size() - cachedBefore;
-			IJ.showStatus( "" );
+			final int newlyCached = SegmentMeshCacher.cacheSegmentsAt( segmentationDisplay, spacing );
 			IJ.showMessage( "Done. Cached " + newlyCached + " segment meshes at " + formatSpacing( spacing ) + " um.\n\nCache: " + MoBIEHelper.getMeshCacheDir() );
 		}
 		catch ( Exception e )

--- a/src/main/java/org/embl/mobie/lib/table/TableView.java
+++ b/src/main/java/org/embl/mobie/lib/table/TableView.java
@@ -34,10 +34,13 @@ import net.imglib2.type.numeric.real.DoubleType;
 import org.embl.mobie.MoBIE;
 import org.embl.mobie.io.util.IOHelper;
 import org.embl.mobie.lib.annotation.AnnotatedRegion;
+import bdv.viewer.Source;
 import org.embl.mobie.lib.data.DataStore;
+import org.embl.mobie.lib.util.MoBIEHelper;
 import org.embl.mobie.lib.image.Image;
 import org.embl.mobie.lib.image.NumericAnnotationImage;
 import org.embl.mobie.lib.serialize.View;
+import org.embl.mobie.lib.serialize.display.SegmentationDisplay;
 import org.embl.mobie.lib.serialize.display.SpotDisplay;
 import org.embl.mobie.lib.source.AnnotationType;
 import org.embl.mobie.lib.view.ViewManager;
@@ -69,7 +72,10 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.io.File;
 import java.util.ArrayList;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -269,7 +275,163 @@ public class TableView< A extends Annotation > implements SelectionListener< A >
 			menu.add( createAddSpotLocationColumnsMenuItem() );
 		}
 
+		if ( display instanceof SegmentationDisplay )
+		{
+			menu.add( createCacheSegmentMeshesMenuItem() );
+		}
+
 		return menu;
+	}
+
+	private JMenuItem createCacheSegmentMeshesMenuItem()
+	{
+		final JMenuItem menuItem = new JMenuItem( "Cache segment meshes..." );
+		menuItem.addActionListener( e -> showCacheSegmentMeshesDialog() );
+		return menuItem;
+	}
+
+	private void showCacheSegmentMeshesDialog()
+	{
+		final List< Double > resolutions = meshResolutionsUm();
+		final String[] choices = new String[ resolutions.size() + 1 ];
+		for ( int i = 0; i < resolutions.size(); i++ )
+			choices[ i ] = formatSpacing( resolutions.get( i ) ) + " um" + ( i == 0 ? " (native)" : "" );
+		choices[ resolutions.size() ] = "Custom...";
+
+		// Default to the finest resolution for which a cache already exists.
+		int defaultIndex = 0;
+		final Double cachedSpacing = finestCachedSpacingUm( display.getName() );
+		if ( cachedSpacing != null )
+			for ( int i = 0; i < resolutions.size(); i++ )
+				if ( Math.abs( resolutions.get( i ) - cachedSpacing ) < 1e-9 )
+					defaultIndex = i;
+
+		final GenericDialog dialog = new GenericDialog( "Cache segment meshes" );
+		dialog.addChoice( "Mesh resolution", choices, choices[ defaultIndex ] );
+		dialog.addMessage( "Computes and caches smoothed meshes of all segments of \"" + display.getName() + "\" at the chosen resolution.\nThe meshes are stored in " + MoBIEHelper.getMeshCacheDir() + "." );
+		dialog.showDialog();
+		if ( dialog.wasCanceled() )
+			return;
+
+		final String selection = dialog.getNextChoice();
+		final double spacing;
+		if ( selection.equals( "Custom..." ) )
+		{
+			final GenericDialog customDialog = new GenericDialog( "Custom mesh resolution" );
+			customDialog.addNumericField( "Spacing (um)", resolutions.isEmpty() ? 0.1 : resolutions.get( 0 ), 4 );
+			customDialog.showDialog();
+			if ( customDialog.wasCanceled() )
+				return;
+			spacing = customDialog.getNextNumber();
+			if ( spacing <= 0 )
+				return;
+		}
+		else
+		{
+			spacing = Double.parseDouble( selection.split( " " )[ 0 ] );
+		}
+
+		final double finalSpacing = spacing;
+		new Thread( () -> cacheSegmentMeshes( finalSpacing ) ).start();
+	}
+
+	@SuppressWarnings( { "unchecked", "rawtypes" } )
+	private void cacheSegmentMeshes( double spacing )
+	{
+		try
+		{
+			final SegmentationDisplay segmentationDisplay = ( SegmentationDisplay ) display;
+			if ( segmentationDisplay.segmentVolumeViewer == null )
+			{
+				IJ.showMessage( "The 3D segment viewer is not initialised for this table." );
+				return;
+			}
+
+			segmentationDisplay.segmentVolumeViewer.setVoxelSpacing( new double[]{ spacing, spacing, spacing } );
+			segmentationDisplay.segmentVolumeViewer.configureMeshCache( display.getName(), MoBIEHelper.getMeshCacheDir() );
+
+			Collection segments = tableModel.annotations();
+			if ( segments.isEmpty() )
+				segments = selectionModel.getSelected();
+			if ( segments.isEmpty() )
+			{
+				IJ.showMessage( "No segments to cache." );
+				return;
+			}
+
+			final int cachedBefore = segmentationDisplay.segmentVolumeViewer.getMeshCache().size();
+			IJ.showStatus( "Caching " + segments.size() + " segment meshes at " + formatSpacing( spacing ) + " um ..." );
+			segmentationDisplay.segmentVolumeViewer.preRenderSegments( segments );
+			final int newlyCached = segmentationDisplay.segmentVolumeViewer.getMeshCache().size() - cachedBefore;
+			IJ.showStatus( "" );
+			IJ.showMessage( "Done. Cached " + newlyCached + " segment meshes at " + formatSpacing( spacing ) + " um.\n\nCache: " + MoBIEHelper.getMeshCacheDir() );
+		}
+		catch ( Exception e )
+		{
+			e.printStackTrace();
+			IJ.showMessage( "Mesh caching failed: " + e.getMessage() );
+		}
+	}
+
+	@SuppressWarnings( { "unchecked", "rawtypes" } )
+	private List< Double > meshResolutionsUm()
+	{
+		final List< Double > resolutions = new ArrayList<>();
+		try
+		{
+			final List images = display.images();
+			if ( ! images.isEmpty() )
+			{
+				final Source source = ( ( Image ) images.get( 0 ) ).getSourcePair().getSource();
+				final java.util.ArrayList< double[] > spacings = MoBIEHelper.getVoxelSpacings( source );
+				for ( final double[] spacing : spacings )
+					if ( spacing != null && spacing.length > 0 )
+						resolutions.add( spacing[ 0 ] );
+			}
+		}
+		catch ( Exception e )
+		{
+			IJ.log( "Could not read the pyramid resolutions: " + e.getMessage() );
+		}
+
+		if ( resolutions.isEmpty() )
+		{
+			// Fallback presets (µm), finest first.
+			for ( final double preset : new double[]{ 0.08, 0.1, 0.2, 0.3, 0.5, 1.0 } )
+				resolutions.add( preset );
+		}
+		return resolutions;
+	}
+
+	private Double finestCachedSpacingUm( String segmentationName )
+	{
+		final File cacheDir = MoBIEHelper.getMeshCacheDir();
+		if ( cacheDir == null || ! cacheDir.isDirectory() )
+			return null;
+
+		final File[] files = cacheDir.listFiles();
+		if ( files == null )
+			return null;
+
+		final Pattern pattern = Pattern.compile( Pattern.quote( segmentationName ) + "-sm\\d+-([0-9_]+)um\\.mel" );
+		Double best = null;
+		for ( final File file : files )
+		{
+			final Matcher matcher = pattern.matcher( file.getName() );
+			if ( matcher.matches() )
+			{
+				final double spacing = Double.parseDouble( matcher.group( 1 ).replace( '_', '.' ) );
+				if ( best == null || spacing < best )
+					best = spacing;
+			}
+		}
+		return best;
+	}
+
+	private static String formatSpacing( double spacing )
+	{
+		final String raw = String.format( "%.3f", spacing ).replaceAll( "0+$", "" );
+		return raw.endsWith( "." ) ? raw.substring( 0, raw.length() - 1 ) : raw;
 	}
 
 	private JMenuItem createAddSpotLocationColumnsMenuItem()

--- a/src/main/java/org/embl/mobie/lib/table/TableView.java
+++ b/src/main/java/org/embl/mobie/lib/table/TableView.java
@@ -37,6 +37,7 @@ import org.embl.mobie.lib.annotation.AnnotatedRegion;
 import bdv.viewer.Source;
 import org.embl.mobie.lib.data.DataStore;
 import org.embl.mobie.lib.util.MoBIEHelper;
+import org.embl.mobie.lib.volume.MeshCache;
 import org.embl.mobie.lib.image.Image;
 import org.embl.mobie.lib.image.NumericAnnotationImage;
 import org.embl.mobie.lib.serialize.View;
@@ -72,10 +73,7 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
-import java.io.File;
 import java.util.ArrayList;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -300,7 +298,7 @@ public class TableView< A extends Annotation > implements SelectionListener< A >
 
 		// Default to the finest resolution for which a cache already exists.
 		int defaultIndex = 0;
-		final Double cachedSpacing = finestCachedSpacingUm( display.getName() );
+		final Double cachedSpacing = MeshCache.findFinestAvailableSpacing( MoBIEHelper.getMeshCacheDir(), display.getName() );
 		if ( cachedSpacing != null )
 			for ( int i = 0; i < resolutions.size(); i++ )
 				if ( Math.abs( resolutions.get( i ) - cachedSpacing ) < 1e-9 )
@@ -401,31 +399,6 @@ public class TableView< A extends Annotation > implements SelectionListener< A >
 				resolutions.add( preset );
 		}
 		return resolutions;
-	}
-
-	private Double finestCachedSpacingUm( String segmentationName )
-	{
-		final File cacheDir = MoBIEHelper.getMeshCacheDir();
-		if ( cacheDir == null || ! cacheDir.isDirectory() )
-			return null;
-
-		final File[] files = cacheDir.listFiles();
-		if ( files == null )
-			return null;
-
-		final Pattern pattern = Pattern.compile( Pattern.quote( segmentationName ) + "-sm\\d+-([0-9_]+)um\\.mel" );
-		Double best = null;
-		for ( final File file : files )
-		{
-			final Matcher matcher = pattern.matcher( file.getName() );
-			if ( matcher.matches() )
-			{
-				final double spacing = Double.parseDouble( matcher.group( 1 ).replace( '_', '.' ) );
-				if ( best == null || spacing < best )
-					best = spacing;
-			}
-		}
-		return best;
 	}
 
 	private static String formatSpacing( double spacing )

--- a/src/main/java/org/embl/mobie/lib/util/MoBIEHelper.java
+++ b/src/main/java/org/embl/mobie/lib/util/MoBIEHelper.java
@@ -1393,4 +1393,10 @@ public abstract class MoBIEHelper
 		}
 		return types;
 	}
+
+	public static File getMeshCacheDir()
+	{
+		final File home = new File( System.getProperty( "user.home" ) );
+		return new File( home, ".mobie/mesh-cache" );
+	}
 }

--- a/src/main/java/org/embl/mobie/lib/util/MoBIEHelper.java
+++ b/src/main/java/org/embl/mobie/lib/util/MoBIEHelper.java
@@ -37,6 +37,7 @@ import bdv.viewer.Source;
 import bdv.viewer.SourceAndConverter;
 import bdv.viewer.ViewerPanel;
 import ij.IJ;
+import ij.Prefs;
 import mpicbg.spim.data.sequence.FinalVoxelDimensions;
 import mpicbg.spim.data.sequence.VoxelDimensions;
 import net.imglib2.*;
@@ -1394,9 +1395,33 @@ public abstract class MoBIEHelper
 		return types;
 	}
 
+	private static final String MESH_CACHE_DIR_PROPERTY = "mobie.meshCacheDir";
+
+	private static final String MESH_CACHE_DIR_PREFS_KEY = "MoBIE.meshCacheDir";
+
+	private static final String DEFAULT_MESH_CACHE_DIR = ".mobie/mesh-cache";
+
+	/**
+	 * Root directory of the disk-backed segment mesh cache.
+	 * <p>
+	 * The location is resolved with the following precedence:
+	 * <ol>
+	 *   <li>system property {@code mobie.meshCacheDir} (handy for CI/headless runs),</li>
+	 *   <li>ImageJ preference {@code MoBIE.meshCacheDir} ({@link ij.Prefs}, the
+	 *       portable per-user preference store across operating systems),</li>
+	 *   <li>default {@code <user.home>/.mobie/mesh-cache}.</li>
+	 * </ol>
+	 */
 	public static File getMeshCacheDir()
 	{
-		final File home = new File( System.getProperty( "user.home" ) );
-		return new File( home, ".mobie/mesh-cache" );
+		final String propertyDir = System.getProperty( MESH_CACHE_DIR_PROPERTY );
+		if ( propertyDir != null && !propertyDir.isEmpty() )
+			return new File( propertyDir );
+
+		final String prefsDir = Prefs.get( MESH_CACHE_DIR_PREFS_KEY, "" );
+		if ( prefsDir != null && !prefsDir.isEmpty() )
+			return new File( prefsDir );
+
+		return new File( System.getProperty( "user.home" ), DEFAULT_MESH_CACHE_DIR );
 	}
 }

--- a/src/main/java/org/embl/mobie/lib/view/ViewManager.java
+++ b/src/main/java/org/embl/mobie/lib/view/ViewManager.java
@@ -32,6 +32,7 @@ import bdv.util.BdvHandle;
 import bdv.viewer.Source;
 import bdv.viewer.SourceAndConverter;
 import ij.IJ;
+import java.io.File;
 import net.imglib2.realtransform.AffineTransform3D;
 import net.imglib2.roi.RealMaskRealInterval;
 import net.imglib2.type.numeric.ARGBType;
@@ -806,6 +807,7 @@ public class ViewManager
 		if ( resolution3dView != null ) {
 			display.segmentVolumeViewer.setVoxelSpacing( ArrayUtils.toPrimitive( display.getResolution3dView() ) );
 		}
+		display.segmentVolumeViewer.configureMeshCache( display.getName(), new File( MoBIEHelper.getMeshCacheDir() ) );
 		display.segmentVolumeViewer.showSegments( display.showSelectedSegmentsIn3d(), true );
 		display.coloringModel.listeners().add( display.segmentVolumeViewer );
 		display.selectionModel.listeners().add( display.segmentVolumeViewer );

--- a/src/main/java/org/embl/mobie/lib/view/ViewManager.java
+++ b/src/main/java/org/embl/mobie/lib/view/ViewManager.java
@@ -807,7 +807,7 @@ public class ViewManager
 		if ( resolution3dView != null ) {
 			display.segmentVolumeViewer.setVoxelSpacing( ArrayUtils.toPrimitive( display.getResolution3dView() ) );
 		}
-		display.segmentVolumeViewer.configureMeshCache( display.getName(), new File( MoBIEHelper.getMeshCacheDir() ) );
+		display.segmentVolumeViewer.configureMeshCache( display.getName(), MoBIEHelper.getMeshCacheDir() );
 		display.segmentVolumeViewer.showSegments( display.showSelectedSegmentsIn3d(), true );
 		display.coloringModel.listeners().add( display.segmentVolumeViewer );
 		display.selectionModel.listeners().add( display.segmentVolumeViewer );

--- a/src/main/java/org/embl/mobie/lib/volume/MeshCache.java
+++ b/src/main/java/org/embl/mobie/lib/volume/MeshCache.java
@@ -41,6 +41,8 @@ import java.nio.channels.FileChannel;
 import java.nio.file.StandardOpenOption;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Disk-backed cache of pre-computed segment meshes.
@@ -307,6 +309,68 @@ public class MeshCache
 	public int size()
 	{
 		return dirtyMeshes.size() + persistedIndex.size();
+	}
+
+	/**
+	 * Scan {@code cacheRoot} for mesh-cache files of the given segmentation
+	 * (any smoothing level) and return the smallest (finest) spacing found, or
+	 * {@code null} if there is no cache file for this segmentation.
+	 *
+	 * @param cacheRoot        root cache directory
+	 * @param segmentationName name used in the cache file name
+	 */
+	public static Double findFinestAvailableSpacing( File cacheRoot, String segmentationName )
+	{
+		if ( cacheRoot == null || ! cacheRoot.isDirectory() )
+			return null;
+
+		final Pattern pattern = Pattern.compile(
+				Pattern.quote( segmentationName ) + "-sm\\d+-([0-9_]+)um\\.mel" );
+
+		final File[] files = cacheRoot.listFiles();
+		if ( files == null )
+			return null;
+
+		Double best = null;
+		for ( final File file : files )
+		{
+			final Matcher matcher = pattern.matcher( file.getName() );
+			if ( ! matcher.matches() )
+				continue;
+			final double spacing = Double.parseDouble( matcher.group( 1 ).replace( '_', '.' ) );
+			if ( best == null || spacing < best )
+				best = spacing;
+		}
+		return best;
+	}
+
+	/**
+	 * Like {@link #findFinestAvailableSpacing(File, String)} but restricted to
+	 * cache files created with the given smoothing iteration count.
+	 */
+	public static Double findFinestAvailableSpacing( File cacheRoot, String segmentationName, int smoothingIterations )
+	{
+		if ( cacheRoot == null || ! cacheRoot.isDirectory() )
+			return null;
+
+		final Pattern pattern = Pattern.compile(
+				Pattern.quote( segmentationName ) + "-sm" + smoothingIterations + "-([0-9_]+)um\\.mel" );
+
+		final File[] files = cacheRoot.listFiles();
+		if ( files == null )
+			return null;
+
+		Double best = null;
+		for ( final File file : files )
+		{
+			final Matcher matcher = pattern.matcher( file.getName() );
+			if ( ! matcher.matches() )
+				continue;
+			final double spacing = Double.parseDouble( matcher.group( 1 ).replace( '_', '.' ) );
+			if ( best == null || spacing < best )
+				best = spacing;
+		}
+		return best;
 	}
 
 	// -- helpers -------------------------------------------------------

--- a/src/main/java/org/embl/mobie/lib/volume/MeshCache.java
+++ b/src/main/java/org/embl/mobie/lib/volume/MeshCache.java
@@ -1,0 +1,275 @@
+/*-
+ * #%L
+ * Fiji viewer for MoBIE projects
+ * %%
+ * Copyright (C) 2018 - 2024 EMBL
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.embl.mobie.lib.volume;
+
+import bdv.viewer.Source;
+import net.imglib2.realtransform.AffineTransform3D;
+import org.embl.mobie.lib.annotation.Segment;
+import org.embl.mobie.lib.source.AnnotationType;
+
+import javax.annotation.Nullable;
+import java.io.*;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Disk-backed cache of pre-computed segment meshes.
+ * <p>
+ * All meshes for a given segmentation + resolution are stored in a single
+ * {@code .mel} (mesh labels) binary file under the cache directory.
+ * The in-memory map doubles as the dirty set — new entries are held in
+ * memory until {@link #flush()} is called.
+ *
+ * <h3>Cache directory layout</h3>
+ * <pre>
+ * ~/.mobie/mesh-cache/
+ *     nuclei-sm5-1_000um.mel
+ *     cells-sm5-0_500um.mel
+ * </pre>
+ *
+ * <h3>File format</h3>
+ * <pre>
+ * [4 bytes magic:  0x4D 0x45 0x4C 0x48  ("MELH")]
+ * [4 bytes version: 1]
+ * [for each segment:
+ *     [8 bytes int64: label ID]
+ *     [4 bytes uint32: vertex count N]
+ *     [N * 12 bytes: float x0, y0, z0, x1, y1, z1, ...]
+ * ]
+ * </pre>
+ */
+public class MeshCache
+{
+	private static final int MAGIC = 0x4D454C48;  // "MELH"
+	private static final int VERSION = 1;
+
+	private final File cacheFile;
+	private final ConcurrentHashMap< Long, float[] > meshes;
+
+	/**
+	 * Create (or open) a mesh cache for the given segmentation at the given
+	 * resolution.  The cache file is loaded into memory immediately if it
+	 * already exists on disk.
+	 *
+	 * @param cacheDir          root directory for all mesh caches
+	 *                          (typically {@code ~/.mobie/mesh-cache/})
+	 * @param segmentationName  human-readable name, e.g. {@code "nuclei"}
+	 * @param smoothingIterations  smoothing level locked into the cached meshes
+	 * @param voxelSpacing      rendering resolution in µm (first element used for filename)
+	 */
+	public MeshCache( File cacheDir, String segmentationName, int smoothingIterations, double[] voxelSpacing )
+	{
+		final String spacingStr = formatSpacing( voxelSpacing );
+		final String fileName = segmentationName + "-sm" + smoothingIterations + "-" + spacingStr + ".mel";
+		this.cacheFile = new File( cacheDir, fileName );
+		this.meshes = new ConcurrentHashMap<>();
+		load();
+	}
+
+	private static String formatSpacing( double[] voxelSpacing )
+	{
+		if ( voxelSpacing == null || voxelSpacing.length == 0 )
+			return "auto";
+
+		final String raw = String.format( "%.3f", voxelSpacing[ 0 ] );
+		// strip trailing zeros, then replace the dot with underscore
+		String trimmed = raw.replaceAll( "0+$", "" );
+		if ( trimmed.endsWith( "." ) )
+			trimmed = trimmed.substring( 0, trimmed.length() - 1 );
+		return trimmed.replace( '.', '_' ) + "um";
+	}
+
+	// -- read/write ----------------------------------------------------
+
+	private void load()
+	{
+		if ( ! cacheFile.exists() )
+			return;
+
+		try ( final DataInputStream in = new DataInputStream(
+				new BufferedInputStream( new FileInputStream( cacheFile ) ) ) )
+		{
+			final int magic = in.readInt();
+			if ( magic != MAGIC )
+				throw new IOException( "Bad magic: " + Integer.toHexString( magic ) );
+
+			final int version = in.readInt();
+			if ( version != VERSION )
+				throw new IOException( "Unsupported version: " + version );
+
+			final byte[] buf = new byte[ 12 ]; // label(8) + count(4) = 12 header bytes
+			while ( true )
+			{
+				// read label ID + vertex count header
+				readFully( in, buf, 0, 12 );
+				final long label = bytesToLong( buf, 0 );
+				final int count = bytesToInt( buf, 8 );
+				if ( count < 0 )
+					break; // sentinel: negative count marks end of stream
+
+				// read vertex data
+				final float[] vertices = new float[ count ];
+				final byte[] vertBuf = new byte[ count * 4 ];
+				readFully( in, vertBuf, 0, vertBuf.length );
+				final ByteBuffer bb = ByteBuffer.wrap( vertBuf ).order( in instanceof java.io.DataInputStream ? ByteOrder.BIG_ENDIAN : ByteOrder.BIG_ENDIAN );
+				bb.order( ByteOrder.BIG_ENDIAN );
+				for ( int i = 0; i < vertices.length; i++ )
+					vertices[ i ] = bb.getFloat();
+
+				meshes.put( label, vertices );
+			}
+		}
+		catch ( EOFException e )
+		{
+			// normal end of file
+		}
+		catch ( IOException e )
+		{
+			System.err.println( "[MeshCache] Failed to load " + cacheFile.getAbsolutePath() + ": " + e.getMessage() );
+		}
+	}
+
+	/**
+	 * Write all cached meshes to disk.
+	 */
+	public synchronized void flush() throws IOException
+	{
+		cacheFile.getParentFile().mkdirs();
+
+		final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		final DataOutputStream out = new DataOutputStream( baos );
+
+		out.writeInt( MAGIC );
+		out.writeInt( VERSION );
+
+		final byte[] header = new byte[ 12 ];
+		for ( final java.util.Map.Entry< Long, float[] > entry : meshes.entrySet() )
+		{
+			final long label = entry.getKey();
+			final float[] vertices = entry.getValue();
+
+			longToBytes( label, header, 0 );
+			intToBytes( vertices.length, header, 8 );
+			out.write( header );
+
+			final byte[] vertBuf = new byte[ vertices.length * 4 ];
+			final ByteBuffer bb = ByteBuffer.wrap( vertBuf ).order( ByteOrder.BIG_ENDIAN );
+			for ( float v : vertices )
+				bb.putFloat( v );
+			out.write( vertBuf );
+		}
+
+		out.flush();
+		Files.write( cacheFile.toPath(), baos.toByteArray(),
+				StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING );
+	}
+
+	// -- public API ----------------------------------------------------
+
+	public boolean hasMesh( long labelId )
+	{
+		return meshes.containsKey( labelId );
+	}
+
+	@Nullable
+	public float[] loadMesh( long labelId )
+	{
+		return meshes.get( labelId );
+	}
+
+	public void storeMesh( long labelId, float[] vertices )
+	{
+		meshes.put( labelId, vertices );
+	}
+
+	public int size()
+	{
+		return meshes.size();
+	}
+
+	// -- helpers -------------------------------------------------------
+
+	private static void readFully( final InputStream in, final byte[] buf, final int off, final int len ) throws IOException
+	{
+		int total = 0;
+		while ( total < len )
+		{
+			final int r = in.read( buf, off + total, len - total );
+			if ( r < 0 )
+				throw new EOFException();
+			total += r;
+		}
+	}
+
+	private static long bytesToLong( byte[] b, int off )
+	{
+		return ( ( long ) ( b[ off ] & 0xFF ) << 56 )
+				| ( ( long ) ( b[ off + 1 ] & 0xFF ) << 48 )
+				| ( ( long ) ( b[ off + 2 ] & 0xFF ) << 40 )
+				| ( ( long ) ( b[ off + 3 ] & 0xFF ) << 32 )
+				| ( ( long ) ( b[ off + 4 ] & 0xFF ) << 24 )
+				| ( ( long ) ( b[ off + 5 ] & 0xFF ) << 16 )
+				| ( ( long ) ( b[ off + 6 ] & 0xFF ) << 8 )
+				| ( b[ off + 7 ] & 0xFF );
+	}
+
+	private static int bytesToInt( byte[] b, int off )
+	{
+		return ( ( b[ off ] & 0xFF ) << 24 )
+				| ( ( b[ off + 1 ] & 0xFF ) << 16 )
+				| ( ( b[ off + 2 ] & 0xFF ) << 8 )
+				| ( b[ off + 3 ] & 0xFF );
+	}
+
+	private static void longToBytes( long v, byte[] b, int off )
+	{
+		b[ off ] = ( byte ) ( v >>> 56 );
+		b[ off + 1 ] = ( byte ) ( v >>> 48 );
+		b[ off + 2 ] = ( byte ) ( v >>> 40 );
+		b[ off + 3 ] = ( byte ) ( v >>> 32 );
+		b[ off + 4 ] = ( byte ) ( v >>> 24 );
+		b[ off + 5 ] = ( byte ) ( v >>> 16 );
+		b[ off + 6 ] = ( byte ) ( v >>> 8 );
+		b[ off + 7 ] = ( byte ) v;
+	}
+
+	private static void intToBytes( int v, byte[] b, int off )
+	{
+		b[ off ] = ( byte ) ( v >>> 24 );
+		b[ off + 1 ] = ( byte ) ( v >>> 16 );
+		b[ off + 2 ] = ( byte ) ( v >>> 8 );
+		b[ off + 3 ] = ( byte ) v;
+	}
+}

--- a/src/main/java/org/embl/mobie/lib/volume/MeshCache.java
+++ b/src/main/java/org/embl/mobie/lib/volume/MeshCache.java
@@ -28,6 +28,8 @@
  */
 package org.embl.mobie.lib.volume;
 
+import ij.IJ;
+
 import java.io.BufferedInputStream;
 import java.io.DataInputStream;
 import java.io.EOFException;
@@ -179,7 +181,7 @@ public class MeshCache
 		}
 		catch ( IOException e )
 		{
-			System.err.println( "[MeshCache] Failed to load " + cacheFile.getAbsolutePath() + ": " + e.getMessage() );
+			IJ.log( "[MeshCache] Failed to load " + cacheFile.getAbsolutePath() + ": " + e.getMessage() );
 		}
 	}
 
@@ -256,7 +258,7 @@ public class MeshCache
 		}
 		catch ( IOException e )
 		{
-			System.err.println( "[MeshCache] Failed to read label " + label + " from " + cacheFile.getAbsolutePath() + ": " + e.getMessage() );
+			IJ.log( "[MeshCache] Failed to read label " + label + " from " + cacheFile.getAbsolutePath() + ": " + e.getMessage() );
 			return null;
 		}
 	}
@@ -301,7 +303,7 @@ public class MeshCache
 			}
 			catch ( IOException e )
 			{
-				System.err.println( "[MeshCache] Failed to persist " + cacheFile.getAbsolutePath() + ": " + e.getMessage() );
+				IJ.log( "[MeshCache] Failed to persist " + cacheFile.getAbsolutePath() + ": " + e.getMessage() );
 			}
 		}
 	}

--- a/src/main/java/org/embl/mobie/lib/volume/MeshCache.java
+++ b/src/main/java/org/embl/mobie/lib/volume/MeshCache.java
@@ -28,20 +28,18 @@
  */
 package org.embl.mobie.lib.volume;
 
-import bdv.viewer.Source;
-import net.imglib2.realtransform.AffineTransform3D;
-import org.embl.mobie.lib.annotation.Segment;
-import org.embl.mobie.lib.source.AnnotationType;
-
-import javax.annotation.Nullable;
-import java.io.*;
+import java.io.BufferedInputStream;
+import java.io.DataInputStream;
+import java.io.EOFException;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.FileChannel;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -49,8 +47,13 @@ import java.util.concurrent.ConcurrentHashMap;
  * <p>
  * All meshes for a given segmentation + resolution are stored in a single
  * {@code .mel} (mesh labels) binary file under the cache directory.
- * The in-memory map doubles as the dirty set — new entries are held in
- * memory until {@link #flush()} is called.
+ * <p>
+ * <h3>Memory-bounded design</h3>
+ * The cache never holds all meshes in RAM. When opened, only a small in-memory
+ * index (label -&gt; file offset) is built; mesh data is read from disk on
+ * demand. Newly stored meshes are buffered in memory and appended to the file
+ * whenever the buffer exceeds {@link #DEFAULT_PERSIST_THRESHOLD} entries (or on
+ * {@link #flush()}), keeping peak memory low even for very large runs.
  *
  * <h3>Cache directory layout</h3>
  * <pre>
@@ -63,7 +66,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * <pre>
  * [4 bytes magic:  0x4D 0x45 0x4C 0x48  ("MELH")]
  * [4 bytes version: 1]
- * [for each segment:
+ * [for each segment (records are appended, never rewritten):
  *     [8 bytes int64: label ID]
  *     [4 bytes uint32: vertex count N]
  *     [N * 12 bytes: float x0, y0, z0, x1, y1, z1, ...]
@@ -75,13 +78,22 @@ public class MeshCache
 	private static final int MAGIC = 0x4D454C48;  // "MELH"
 	private static final int VERSION = 1;
 
+	/** Number of buffered, not-yet-appended meshes before an automatic persist. */
+	private static final int DEFAULT_PERSIST_THRESHOLD = 256;
+
 	private final File cacheFile;
-	private final ConcurrentHashMap< Long, float[] > meshes;
+
+	/** Meshes stored but not yet appended to the file; bounded by the persist threshold. */
+	private final ConcurrentHashMap< Long, float[] > dirtyMeshes;
+
+	/** label -&gt; { byte offset of the record in the file, vertex count }. */
+	private final ConcurrentHashMap< Long, long[] > persistedIndex;
+
+	private final int persistThreshold;
 
 	/**
 	 * Create (or open) a mesh cache for the given segmentation at the given
-	 * resolution.  The cache file is loaded into memory immediately if it
-	 * already exists on disk.
+	 * resolution.
 	 *
 	 * @param cacheDir          root directory for all mesh caches
 	 *                          (typically {@code ~/.mobie/mesh-cache/})
@@ -91,10 +103,20 @@ public class MeshCache
 	 */
 	public MeshCache( File cacheDir, String segmentationName, int smoothingIterations, double[] voxelSpacing )
 	{
+		this( cacheDir, segmentationName, smoothingIterations, voxelSpacing, DEFAULT_PERSIST_THRESHOLD );
+	}
+
+	/**
+	 * Package-private constructor with an explicit persist threshold (used by tests).
+	 */
+	MeshCache( File cacheDir, String segmentationName, int smoothingIterations, double[] voxelSpacing, int persistThreshold )
+	{
 		final String spacingStr = formatSpacing( voxelSpacing );
 		final String fileName = segmentationName + "-sm" + smoothingIterations + "-" + spacingStr + ".mel";
 		this.cacheFile = new File( cacheDir, fileName );
-		this.meshes = new ConcurrentHashMap<>();
+		this.persistThreshold = Math.max( 1, persistThreshold );
+		this.dirtyMeshes = new ConcurrentHashMap<>();
+		this.persistedIndex = new ConcurrentHashMap<>();
 		load();
 	}
 
@@ -113,6 +135,10 @@ public class MeshCache
 
 	// -- read/write ----------------------------------------------------
 
+	/**
+	 * Scan the cache file and build the in-memory label index without loading
+	 * any vertex data.
+	 */
 	private void load()
 	{
 		if ( ! cacheFile.exists() )
@@ -129,26 +155,20 @@ public class MeshCache
 			if ( version != VERSION )
 				throw new IOException( "Unsupported version: " + version );
 
-			final byte[] buf = new byte[ 12 ]; // label(8) + count(4) = 12 header bytes
+			final byte[] header = new byte[ 12 ];
+			long offset = 8; // magic + version
 			while ( true )
 			{
-				// read label ID + vertex count header
-				readFully( in, buf, 0, 12 );
-				final long label = bytesToLong( buf, 0 );
-				final int count = bytesToInt( buf, 8 );
+				readFully( in, header, 0, 12 );
+				final long label = bytesToLong( header, 0 );
+				final int count = bytesToInt( header, 8 );
 				if ( count < 0 )
 					break; // sentinel: negative count marks end of stream
 
-				// read vertex data
-				final float[] vertices = new float[ count ];
-				final byte[] vertBuf = new byte[ count * 4 ];
-				readFully( in, vertBuf, 0, vertBuf.length );
-				final ByteBuffer bb = ByteBuffer.wrap( vertBuf ).order( in instanceof java.io.DataInputStream ? ByteOrder.BIG_ENDIAN : ByteOrder.BIG_ENDIAN );
-				bb.order( ByteOrder.BIG_ENDIAN );
-				for ( int i = 0; i < vertices.length; i++ )
-					vertices[ i ] = bb.getFloat();
-
-				meshes.put( label, vertices );
+				// Only index records whose payload could be read completely.
+				skipFully( in, ( long ) count * 4 );
+				persistedIndex.put( label, new long[] { offset, count } );
+				offset += 12 + ( long ) count * 4;
 			}
 		}
 		catch ( EOFException e )
@@ -162,61 +182,131 @@ public class MeshCache
 	}
 
 	/**
-	 * Write all cached meshes to disk.
+	 * Append all currently buffered meshes to the cache file.
+	 */
+	private synchronized void persistDirty() throws IOException
+	{
+		if ( dirtyMeshes.isEmpty() )
+			return;
+
+		cacheFile.getParentFile().mkdirs();
+
+		try ( final FileChannel channel = FileChannel.open(
+				cacheFile.toPath(), StandardOpenOption.CREATE, StandardOpenOption.WRITE ) )
+		{
+			if ( channel.size() == 0 )
+			{
+				channel.write( ByteBuffer.wrap( new byte[] {
+						( byte ) ( MAGIC >>> 24 ), ( byte ) ( MAGIC >>> 16 ),
+						( byte ) ( MAGIC >>> 8 ), ( byte ) MAGIC,
+						( byte ) ( VERSION >>> 24 ), ( byte ) ( VERSION >>> 16 ),
+						( byte ) ( VERSION >>> 8 ), ( byte ) VERSION } ) );
+			}
+
+			final ByteBuffer record = ByteBuffer.allocate( 12 ).order( ByteOrder.BIG_ENDIAN );
+			for ( final Map.Entry< Long, float[] > entry : dirtyMeshes.entrySet() )
+			{
+				final long recordStart = channel.size();
+				channel.position( recordStart );
+
+				final float[] vertices = entry.getValue();
+				record.clear();
+				record.putLong( entry.getKey() );
+				record.putInt( vertices.length );
+				record.flip();
+				writeFully( channel, record );
+
+				final ByteBuffer verticesBuffer = ByteBuffer.allocate( vertices.length * 4 ).order( ByteOrder.BIG_ENDIAN );
+				verticesBuffer.asFloatBuffer().put( vertices );
+				writeFully( channel, verticesBuffer );
+
+				persistedIndex.put( entry.getKey(), new long[] { recordStart, vertices.length } );
+			}
+			channel.force( false );
+		}
+
+		dirtyMeshes.clear();
+	}
+
+	private static void writeFully( final FileChannel channel, final ByteBuffer buffer ) throws IOException
+	{
+		while ( buffer.hasRemaining() )
+			channel.write( buffer );
+	}
+
+	private float[] readPersisted( long label, long recordOffset, int count )
+	{
+		try ( final FileChannel channel = FileChannel.open( cacheFile.toPath(), StandardOpenOption.READ ) )
+		{
+			final ByteBuffer verticesBuffer = ByteBuffer.allocate( count * 4 ).order( ByteOrder.BIG_ENDIAN );
+			long position = recordOffset + 12;
+			while ( verticesBuffer.hasRemaining() )
+			{
+				final int read = channel.read( verticesBuffer, position );
+				if ( read < 0 )
+					throw new EOFException( "Unexpected end of file while reading label " + label );
+				position += read;
+			}
+			verticesBuffer.flip();
+			final float[] vertices = new float[ count ];
+			verticesBuffer.asFloatBuffer().get( vertices );
+			return vertices;
+		}
+		catch ( IOException e )
+		{
+			System.err.println( "[MeshCache] Failed to read label " + label + " from " + cacheFile.getAbsolutePath() + ": " + e.getMessage() );
+			return null;
+		}
+	}
+
+	/**
+	 * Write all buffered meshes to disk.
 	 */
 	public synchronized void flush() throws IOException
 	{
-		cacheFile.getParentFile().mkdirs();
-
-		final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-		final DataOutputStream out = new DataOutputStream( baos );
-
-		out.writeInt( MAGIC );
-		out.writeInt( VERSION );
-
-		final byte[] header = new byte[ 12 ];
-		for ( final java.util.Map.Entry< Long, float[] > entry : meshes.entrySet() )
-		{
-			final long label = entry.getKey();
-			final float[] vertices = entry.getValue();
-
-			longToBytes( label, header, 0 );
-			intToBytes( vertices.length, header, 8 );
-			out.write( header );
-
-			final byte[] vertBuf = new byte[ vertices.length * 4 ];
-			final ByteBuffer bb = ByteBuffer.wrap( vertBuf ).order( ByteOrder.BIG_ENDIAN );
-			for ( float v : vertices )
-				bb.putFloat( v );
-			out.write( vertBuf );
-		}
-
-		out.flush();
-		Files.write( cacheFile.toPath(), baos.toByteArray(),
-				StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING );
+		persistDirty();
 	}
 
 	// -- public API ----------------------------------------------------
 
 	public boolean hasMesh( long labelId )
 	{
-		return meshes.containsKey( labelId );
+		return dirtyMeshes.containsKey( labelId ) || persistedIndex.containsKey( labelId );
 	}
 
-	@Nullable
+	@javax.annotation.Nullable
 	public float[] loadMesh( long labelId )
 	{
-		return meshes.get( labelId );
+		final float[] mesh = dirtyMeshes.get( labelId );
+		if ( mesh != null )
+			return mesh;
+
+		final long[] record = persistedIndex.get( labelId );
+		if ( record == null )
+			return null;
+
+		return readPersisted( labelId, record[ 0 ], ( int ) record[ 1 ] );
 	}
 
-	public void storeMesh( long labelId, float[] vertices )
+	public synchronized void storeMesh( long labelId, float[] vertices )
 	{
-		meshes.put( labelId, vertices );
+		dirtyMeshes.put( labelId, vertices );
+		if ( dirtyMeshes.size() >= persistThreshold )
+		{
+			try
+			{
+				persistDirty();
+			}
+			catch ( IOException e )
+			{
+				System.err.println( "[MeshCache] Failed to persist " + cacheFile.getAbsolutePath() + ": " + e.getMessage() );
+			}
+		}
 	}
 
 	public int size()
 	{
-		return meshes.size();
+		return dirtyMeshes.size() + persistedIndex.size();
 	}
 
 	// -- helpers -------------------------------------------------------
@@ -230,6 +320,25 @@ public class MeshCache
 			if ( r < 0 )
 				throw new EOFException();
 			total += r;
+		}
+	}
+
+	private static void skipFully( final InputStream in, final long len ) throws IOException
+	{
+		long remaining = len;
+		while ( remaining > 0 )
+		{
+			final long skipped = in.skip( remaining );
+			if ( skipped <= 0 )
+			{
+				if ( in.read() < 0 )
+					throw new EOFException();
+				remaining--;
+			}
+			else
+			{
+				remaining -= skipped;
+			}
 		}
 	}
 
@@ -251,25 +360,5 @@ public class MeshCache
 				| ( ( b[ off + 1 ] & 0xFF ) << 16 )
 				| ( ( b[ off + 2 ] & 0xFF ) << 8 )
 				| ( b[ off + 3 ] & 0xFF );
-	}
-
-	private static void longToBytes( long v, byte[] b, int off )
-	{
-		b[ off ] = ( byte ) ( v >>> 56 );
-		b[ off + 1 ] = ( byte ) ( v >>> 48 );
-		b[ off + 2 ] = ( byte ) ( v >>> 40 );
-		b[ off + 3 ] = ( byte ) ( v >>> 32 );
-		b[ off + 4 ] = ( byte ) ( v >>> 24 );
-		b[ off + 5 ] = ( byte ) ( v >>> 16 );
-		b[ off + 6 ] = ( byte ) ( v >>> 8 );
-		b[ off + 7 ] = ( byte ) v;
-	}
-
-	private static void intToBytes( int v, byte[] b, int off )
-	{
-		b[ off ] = ( byte ) ( v >>> 24 );
-		b[ off + 1 ] = ( byte ) ( v >>> 16 );
-		b[ off + 2 ] = ( byte ) ( v >>> 8 );
-		b[ off + 3 ] = ( byte ) v;
 	}
 }

--- a/src/main/java/org/embl/mobie/lib/volume/MeshCreator.java
+++ b/src/main/java/org/embl/mobie/lib/volume/MeshCreator.java
@@ -193,8 +193,7 @@ public class MeshCreator< S extends Segment >
 			catch ( Exception e )
 			{
 				final String msg = "Could not create mesh for segment " + segment.label() + " at time point " + segment.timePoint();
-				//IJ.showMessage( msg );
-				throw new RuntimeException( msg );
+				throw new RuntimeException( msg, e );
 			}
 		}
 

--- a/src/main/java/org/embl/mobie/lib/volume/MeshCreator.java
+++ b/src/main/java/org/embl/mobie/lib/volume/MeshCreator.java
@@ -57,11 +57,22 @@ public class MeshCreator< S extends Segment >
 {
 	private final int meshSmoothingIterations;
 	private final double maxNumSegmentVoxels;
+	private MeshCache meshCache;
 
 	public MeshCreator( int meshSmoothingIterations, double maxNumSegmentVoxels )
 	{
 		this.meshSmoothingIterations = meshSmoothingIterations;
 		this.maxNumSegmentVoxels = maxNumSegmentVoxels;
+	}
+
+	public void setMeshCache( MeshCache meshCache )
+	{
+		this.meshCache = meshCache;
+	}
+
+	public MeshCache getMeshCache()
+	{
+		return meshCache;
 	}
 
 	private float[] createMesh( S segment, @Nullable double[] targetVoxelSpacing, Source< AnnotationType< S > > source )
@@ -153,11 +164,31 @@ public class MeshCreator< S extends Segment >
 
 	private CustomTriangleMesh createCustomTriangleMesh( S segment, @Nullable double[] voxelSpacing, boolean recomputeMesh, Source< AnnotationType< S > >  source )
 	{
+		// 1. Check in-memory segment cache
+		if ( segment.mesh() == null || recomputeMesh )
+		{
+			// 2. Check disk cache (if available)
+			if ( meshCache != null && ! recomputeMesh )
+			{
+				final long label = segment.label();
+				final float[] cachedMesh = meshCache.loadMesh( label );
+				if ( cachedMesh != null )
+				{
+					segment.setMesh( cachedMesh );
+				}
+			}
+		}
+
 		if ( segment.mesh() == null || recomputeMesh )
 		{
 			try
 			{
-				segment.setMesh( createMesh( segment, voxelSpacing, source ) );
+				final float[] mesh = createMesh( segment, voxelSpacing, source );
+				segment.setMesh( mesh );
+
+				// 3. Store in disk cache (if available)
+				if ( meshCache != null )
+					meshCache.storeMesh( segment.label(), mesh );
 			}
 			catch ( Exception e )
 			{

--- a/src/main/java/org/embl/mobie/lib/volume/MeshCreator.java
+++ b/src/main/java/org/embl/mobie/lib/volume/MeshCreator.java
@@ -77,18 +77,13 @@ public class MeshCreator< S extends Segment >
 
 	private float[] createMesh( S segment, @Nullable double[] targetVoxelSpacing, Source< AnnotationType< S > > source )
 	{
-		int renderingLevel = getLevel( segment, source, targetVoxelSpacing );
-
-		final AffineTransform3D sourceTransform = new AffineTransform3D();
 		final int timePoint = segment.timePoint() == null ? 0 : segment.timePoint();
-		source.getSourceTransform( timePoint, renderingLevel, sourceTransform );
-
-		final RandomAccessibleInterval< AnnotationType< S > >  rai = source.getSource( timePoint, renderingLevel );
+		final int renderingLevel = getLevel( segment, source, targetVoxelSpacing );
 
 		if ( segment.boundingBox() == null )
 		{
-			// compute bounding box in voxel space
-			//
+			// compute the bounding box in real space, flood-filling at the
+			// initially chosen resolution level
 			RealPoint position;
 			try
 			{
@@ -98,6 +93,10 @@ public class MeshCreator< S extends Segment >
 			{
 				throw new UnsupportedOperationException( "The location of segment " + segment.label() + " could not be determined and thus no mesh could be created;\npossibly the corresponding table has no anchor point entries for this segment" );
 			}
+
+			final AffineTransform3D sourceTransform = new AffineTransform3D();
+			source.getSourceTransform( timePoint, renderingLevel, sourceTransform );
+			final RandomAccessibleInterval< AnnotationType< S > > rai = source.getSource( timePoint, renderingLevel );
 
 			final long[] voxelPositionInSource = SourceAndConverterHelper.getVoxelPositionInSource( source, position, timePoint, renderingLevel );
 
@@ -109,50 +108,55 @@ public class MeshCreator< S extends Segment >
 			floodFill.run( voxelPositionInSource );
 			final RandomAccessibleInterval< BitType > mask = floodFill.getCroppedRegionMask();
 
-			// set segment bounding box in real space
-			//
 			final FinalRealInterval realBounds = sourceTransform.estimateBounds( mask );
 			segment.setBoundingBox( realBounds );
 		}
 
-		Interval voxelBounds = Intervals.smallestContainingInterval( sourceTransform.inverse().estimateBounds( segment.boundingBox() ) );
-
-		if ( ! Intervals.contains( rai, voxelBounds ) )
+		// Extract the surface at the chosen resolution. If the object is too
+		// small for that mipmap level (or lies at the image border) it may only
+		// be present at finer levels, so step down towards level 0 before
+		// giving up.
+		for ( int level = renderingLevel; level >= 0; level-- )
 		{
-			System.out.println("Warning: The segment bounding box " + voxelBounds + " is not fully contained in the image interval: " + Arrays.toString( Intervals.minAsLongArray( rai ) ) + "-" +  Arrays.toString( Intervals.maxAsDoubleArray( rai ) ) + "; taking the intersection.");
-			voxelBounds = Intervals.intersect( rai, voxelBounds );
+			final AffineTransform3D sourceTransform = new AffineTransform3D();
+			source.getSourceTransform( timePoint, level, sourceTransform );
+
+			final RandomAccessibleInterval< AnnotationType< S > > rai = source.getSource( timePoint, level );
+
+			Interval voxelBounds = Intervals.smallestContainingInterval( sourceTransform.inverse().estimateBounds( segment.boundingBox() ) );
+
+			if ( ! Intervals.contains( rai, voxelBounds ) )
+				voxelBounds = Intervals.intersect( rai, voxelBounds );
+
+			if ( Intervals.numElements( voxelBounds ) == 0 )
+				continue; // outside of the image at this level
+
+			final AnnotationType< S > type = source.getType();
+			final AnnotationType< S > variable = type.createVariable();
+			final RandomAccessible< AnnotationType< S > > rra = Views.extendValue( rai, variable );
+
+			final MeshExtractor meshExtractor = new MeshExtractor(
+					rra,
+					voxelBounds,
+					new AffineTransform3D(),
+					new int[]{ 1, 1, 1 },
+					() -> false );
+
+			final float[] mesh = meshExtractor.extractMesh( new AnnotationType( segment ) );
+
+			if ( mesh.length == 0 )
+				continue; // label not present at this level; try a finer one
+
+			// TODO: instead of transforming the mesh, one could
+			//  also transform the universe content that is created
+			//  from this mesh
+			//  Note that for the image volume rendering (@code ImageVolumeViewer)
+			//  we need to transform the images as content,
+			//  and thus it may be more consistent do to the same for the meshes?!
+			return MeshTransformer.transform( mesh, sourceTransform );
 		}
 
-		final long numElements = Intervals.numElements( voxelBounds );
-
-		if ( numElements == 0 )
-			throw new RuntimeException("The segment is not within the image volume.");
-
-		final AnnotationType< S > type = source.getType();
-		final AnnotationType< S > variable = type.createVariable();
-		final RandomAccessible< AnnotationType< S > > rra = Views.extendValue( rai, variable );
-
-		final MeshExtractor meshExtractor = new MeshExtractor(
-				rra,
-				voxelBounds,
-				new AffineTransform3D(),
-				new int[]{ 1, 1, 1 },
-				() -> false );
-
-		final float[] mesh = meshExtractor.extractMesh( new AnnotationType( segment ) );
-
-		if ( mesh.length == 0 )
-			throw new RuntimeException("The mesh has zero vertices.");
-
-		// TODO: instead of transformation the mesh, one could
-		//  also transform the universe content that is created
-		//  from this mesh
-		//  Note that for the image volume rendering (@code ImageVolumeViewer)
-		//  we need to transform the images as content,
-		//  and thus it may be more consistent do to the same for the meshes?!
-		final float[] transformedMesh = MeshTransformer.transform( mesh, sourceTransform );
-
-		return transformedMesh;
+		throw new RuntimeException( "Segment " + segment.label() + " has no voxels in the image volume at any resolution level." );
 	}
 
 	public CustomTriangleMesh createSmoothCustomTriangleMesh( S segment, @Nullable double[] voxelSpacing, boolean recomputeMesh, Source< AnnotationType< S > > source )

--- a/src/main/java/org/embl/mobie/lib/volume/SegmentMeshCacher.java
+++ b/src/main/java/org/embl/mobie/lib/volume/SegmentMeshCacher.java
@@ -1,0 +1,90 @@
+/*-
+ * #%L
+ * Fiji viewer for MoBIE projects
+ * %%
+ * Copyright (C) 2018 - 2024 EMBL
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.embl.mobie.lib.volume;
+
+import org.embl.mobie.lib.serialize.display.SegmentationDisplay;
+import org.embl.mobie.lib.util.MoBIEHelper;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * Pre-renders (and persists) smoothed meshes of all segments of a segmentation
+ * display through the disk-backed {@link MeshCache}.
+ */
+public final class SegmentMeshCacher
+{
+	private SegmentMeshCacher()
+	{}
+
+	/**
+	 * Compute and cache smoothed meshes of all segments of the given
+	 * segmentation display at the given isotropic voxel spacing.
+	 *
+	 * @param display   segmentation display whose segments should be cached
+	 * @param spacingUm isotropic voxel spacing in µm; if {@code <= 0} the
+	 *                  viewer's current (or finest cached) spacing is kept
+	 * @return the number of meshes that were newly cached
+	 * @throws IllegalStateException if no 3D segment viewer or no mesh cache
+	 *                               could be configured for the display
+	 */
+	@SuppressWarnings( { "unchecked", "rawtypes" } )
+	public static int cacheSegmentsAt( SegmentationDisplay display, double spacingUm )
+	{
+		if ( display.segmentVolumeViewer == null )
+			throw new IllegalStateException(
+					"The 3D segment viewer is not initialised for display \"" + display.getName() + "\"." );
+
+		if ( spacingUm > 0 )
+			display.segmentVolumeViewer.setVoxelSpacing( new double[]{ spacingUm, spacingUm, spacingUm } );
+
+		display.segmentVolumeViewer.configureMeshCache( display.getName(), MoBIEHelper.getMeshCacheDir() );
+
+		if ( display.segmentVolumeViewer.getMeshCache() == null )
+			throw new IllegalStateException(
+					"No mesh cache could be configured for display \"" + display.getName()
+							+ "\". Specify a voxel spacing > 0 (µm) or first cache meshes of this segmentation at a fixed resolution." );
+
+		final Collection segments = segments( display );
+		if ( segments.isEmpty() )
+			return 0;
+
+		final int cachedBefore = display.segmentVolumeViewer.getMeshCache().size();
+		display.segmentVolumeViewer.preRenderSegments( segments );
+		return display.segmentVolumeViewer.getMeshCache().size() - cachedBefore;
+	}
+
+	@SuppressWarnings( { "unchecked", "rawtypes" } )
+	private static Collection segments( SegmentationDisplay display )
+	{
+		if ( display.getAnnData() != null && display.getAnnData().getTable() != null )
+			return new ArrayList( display.getAnnData().getTable().annotations() );
+		return display.selectionModel.getSelected();
+	}
+}

--- a/src/main/java/org/embl/mobie/lib/volume/SegmentVolumeViewer.java
+++ b/src/main/java/org/embl/mobie/lib/volume/SegmentVolumeViewer.java
@@ -215,6 +215,8 @@ public class SegmentVolumeViewer< S extends Segment > implements ColoringListene
 		final AtomicInteger progress = new AtomicInteger( 0 );
 		final int total = pending.size();
 		final ArrayList< Future< ? > > futures = ThreadHelper.getFutures();
+		final AtomicInteger failures = new AtomicInteger( 0 );
+		final int maxLoggedFailures = 10;
 
 		// Update the status bar on a time basis rather than on a fixed number
 		// of finished meshes, so that very fast and very slow segments both
@@ -236,7 +238,13 @@ public class SegmentVolumeViewer< S extends Segment > implements ColoringListene
 				}
 				catch ( Exception e )
 				{
-					System.err.println( "[MoBIE] Could not pre-render mesh for segment " + segment.label() + ": " + e.getMessage() );
+					final int failureCount = failures.incrementAndGet();
+					if ( failureCount <= maxLoggedFailures )
+					{
+						final Throwable cause = e.getCause();
+						System.err.println( "[MoBIE] Could not pre-render mesh for segment " + segment.label() + ": " + e.getMessage()
+								+ ( cause != null ? " (cause: " + cause.getMessage() + ")" : "" ) );
+					}
 				}
 				finally
 				{
@@ -263,6 +271,9 @@ public class SegmentVolumeViewer< S extends Segment > implements ColoringListene
 		{
 			System.err.println( "[MoBIE] Failed to flush mesh cache: " + e.getMessage() );
 		}
+
+		if ( failures.get() > 0 )
+			System.err.println( "[MoBIE] " + failures.get() + " of " + total + " meshes could not be pre-rendered." );
 	}
 
 	public MeshCache getMeshCache()

--- a/src/main/java/org/embl/mobie/lib/volume/SegmentVolumeViewer.java
+++ b/src/main/java/org/embl/mobie/lib/volume/SegmentVolumeViewer.java
@@ -63,6 +63,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.embl.mobie.lib.util.ThreadHelper;
 
@@ -202,6 +203,13 @@ public class SegmentVolumeViewer< S extends Segment > implements ColoringListene
 		final int total = pending.size();
 		final ArrayList< Future< ? > > futures = ThreadHelper.getFutures();
 
+		// Update the status bar on a time basis rather than on a fixed number
+		// of finished meshes, so that very fast and very slow segments both
+		// produce a steady ~10 s update cadence.
+		final long statusIntervalMillis = 10_000;
+		final AtomicLong lastStatusTimeMillis = new AtomicLong( System.currentTimeMillis() );
+		IJ.showStatus( "Pre-rendering meshes: 0/" + total );
+
 		for ( S segment : pending )
 		{
 			futures.add( ThreadHelper.executorService.submit( () ->
@@ -220,7 +228,13 @@ public class SegmentVolumeViewer< S extends Segment > implements ColoringListene
 				finally
 				{
 					final int done = progress.incrementAndGet();
-					if ( done % 100 == 0 || done == total )
+					final long now = System.currentTimeMillis();
+					final long lastStatusTime = lastStatusTimeMillis.get();
+					// Always report the final count; otherwise report at most
+					// once per interval (guarded by the atomic timestamp).
+					if ( done == total
+							|| ( now - lastStatusTime >= statusIntervalMillis
+									&& lastStatusTimeMillis.compareAndSet( lastStatusTime, now ) ) )
 						IJ.showStatus( "Pre-rendering meshes: " + done + "/" + total );
 				}
 			} ) );

--- a/src/main/java/org/embl/mobie/lib/volume/SegmentVolumeViewer.java
+++ b/src/main/java/org/embl/mobie/lib/volume/SegmentVolumeViewer.java
@@ -161,9 +161,10 @@ public class SegmentVolumeViewer< S extends Segment > implements ColoringListene
 	 * <p>
 	 * If no fixed voxel spacing has been set (e.g. the view declares no
 	 * {@code resolution3d}), the best - i.e. finest - resolution for which a
-	 * mesh cache already exists for this segmentation is used automatically;
-	 * only if no cache exists at all is the cache left unconfigured (auto
-	 * resolution, no caching).
+	 * mesh cache already exists for this segmentation is used automatically.
+	 * If no cache exists at all, the cache is left unconfigured (auto
+	 * resolution, no caching) and a log message explains how to pre-cache the
+	 * segment meshes from the table's Misc menu.
 	 *
 	 * @param segmentationName  human-readable name used in the cache file name
 	 * @param cacheRoot         root cache directory
@@ -176,7 +177,13 @@ public class SegmentVolumeViewer< S extends Segment > implements ColoringListene
 			// Default to the finest resolution for which a cache already exists.
 			final Double bestSpacing = MeshCache.findFinestAvailableSpacing( cacheRoot, segmentationName, meshSmoothingIterations );
 			if ( bestSpacing == null )
+			{
+				// No cache yet: meshes are computed on demand. Tell the user how
+				// to pre-cache them from the segmentation table's Misc menu.
+				IJ.log( "[MoBIE] No cached meshes for \"" + segmentationName + "\": segment meshes will be computed on demand (auto resolution)." );
+				IJ.log( "[MoBIE] To pre-cache them at a fixed resolution, open the table of this segmentation and use 'Misc' > 'Cache segment meshes...'." );
 				return; // no cached resolution yet: auto resolution, no caching
+			}
 			voxelSpacing = new double[] { bestSpacing, bestSpacing, bestSpacing };
 			IJ.log( "[MoBIE] Using best available mesh cache resolution " + bestSpacing + " um for " + segmentationName );
 		}

--- a/src/main/java/org/embl/mobie/lib/volume/SegmentVolumeViewer.java
+++ b/src/main/java/org/embl/mobie/lib/volume/SegmentVolumeViewer.java
@@ -186,6 +186,8 @@ public class SegmentVolumeViewer< S extends Segment > implements ColoringListene
 			}
 			voxelSpacing = new double[] { bestSpacing, bestSpacing, bestSpacing };
 			IJ.log( "[MoBIE] Using best available mesh cache resolution " + bestSpacing + " um for " + segmentationName );
+			IJ.log( "[MoBIE] Tip: to keep this cache but stop using it (e.g. to regenerate the meshes at another resolution), rename its .mel file(s) in "
+					+ cacheRoot + ", for example add a NOT_IN_USE_ prefix. Renamed files are ignored." );
 		}
 
 		this.meshCache = new MeshCache( cacheRoot, segmentationName, meshSmoothingIterations, voxelSpacing );

--- a/src/main/java/org/embl/mobie/lib/volume/SegmentVolumeViewer.java
+++ b/src/main/java/org/embl/mobie/lib/volume/SegmentVolumeViewer.java
@@ -30,6 +30,7 @@ package org.embl.mobie.lib.volume;
 
 import bdv.viewer.Source;
 import customnode.CustomTriangleMesh;
+import ij.IJ;
 import ij3d.Content;
 import ij3d.Image3DUniverse;
 import ij3d.ImageWindow3D;
@@ -60,6 +61,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.embl.mobie.lib.util.ThreadHelper;
 
 public class SegmentVolumeViewer< S extends Segment > implements ColoringListener, SelectionListener< S >
 {
@@ -168,7 +173,7 @@ public class SegmentVolumeViewer< S extends Segment > implements ColoringListene
 
 	/**
 	 * Pre-render meshes for the given segments and persist them to disk.
-	 * This is an expensive, blocking operation — call from a background thread.
+	 * Segments are processed in parallel using the shared thread pool.
 	 *
 	 * @param segments  segments whose meshes should be computed and cached.
 	 */
@@ -180,26 +185,48 @@ public class SegmentVolumeViewer< S extends Segment > implements ColoringListene
 			return;
 		}
 
+		final List< S > pending = new ArrayList<>();
 		for ( S segment : segments )
 		{
 			if ( segment.timePoint() != null && segment.timePoint() != currentTimePoint )
 				continue;
-
 			if ( meshCache.hasMesh( segment.label() ) )
 				continue;
-
-			try
-			{
-				final Source< AnnotationType< S > > source = getSource( segment );
-				// createSmoothCustomTriangleMesh will check the cache first,
-				// compute if missing, and store to cache afterwards
-				meshCreator.createSmoothCustomTriangleMesh( segment, voxelSpacing, false, source );
-			}
-			catch ( Exception e )
-			{
-				System.err.println( "[MoBIE] Could not pre-render mesh for segment " + segment.label() + ": " + e.getMessage() );
-			}
+			pending.add( segment );
 		}
+
+		if ( pending.isEmpty() )
+			return;
+
+		final AtomicInteger progress = new AtomicInteger( 0 );
+		final int total = pending.size();
+		final ArrayList< Future< ? > > futures = ThreadHelper.getFutures();
+
+		for ( S segment : pending )
+		{
+			futures.add( ThreadHelper.executorService.submit( () ->
+			{
+				try
+				{
+					final Source< AnnotationType< S > > source = getSource( segment );
+					// createSmoothCustomTriangleMesh will check the cache first,
+					// compute if missing, and store to cache afterwards
+					meshCreator.createSmoothCustomTriangleMesh( segment, voxelSpacing, false, source );
+				}
+				catch ( Exception e )
+				{
+					System.err.println( "[MoBIE] Could not pre-render mesh for segment " + segment.label() + ": " + e.getMessage() );
+				}
+				finally
+				{
+					final int done = progress.incrementAndGet();
+					if ( done % 100 == 0 || done == total )
+						IJ.showStatus( "Pre-rendering meshes: " + done + "/" + total );
+				}
+			} ) );
+		}
+
+		ThreadHelper.waitUntilFinished( futures );
 
 		try
 		{

--- a/src/main/java/org/embl/mobie/lib/volume/SegmentVolumeViewer.java
+++ b/src/main/java/org/embl/mobie/lib/volume/SegmentVolumeViewer.java
@@ -51,6 +51,8 @@ import org.jogamp.vecmath.Color3f;
 
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -80,6 +82,7 @@ public class SegmentVolumeViewer< S extends Segment > implements ColoringListene
 	private double[] voxelSpacing; // desired voxel spacings; null = auto
 	private int currentTimePoint = 0;
 	private final MeshCreator< S > meshCreator;
+	private MeshCache meshCache;
 	private List< VisibilityListener > listeners = new ArrayList<>(  );
 	private ImageWindow3D window;
 	private Image3DUniverse universe;
@@ -141,6 +144,76 @@ public class SegmentVolumeViewer< S extends Segment > implements ColoringListene
 	public void setMaxNumVoxels( long maxNumVoxels )
 	{
 		this.maxNumVoxels = maxNumVoxels;
+	}
+
+	/**
+	 * Configure a persistent mesh cache for this viewer.
+	 * <p>
+	 * When set, mesh data is loaded from disk before computing and stored
+	 * to disk after computing.  Cached meshes are pre-smoothed, so loading
+	 * skips both marching cubes and smoothing.
+	 *
+	 * @param segmentationName  human-readable name used in the cache file name
+	 * @param cacheRoot         root cache directory
+	 *                          (typically {@code ~/.mobie/mesh-cache/})
+	 */
+	public void configureMeshCache( String segmentationName, File cacheRoot )
+	{
+		if ( voxelSpacing == null )
+			return; // cannot cache without fixed voxel spacing
+
+		this.meshCache = new MeshCache( cacheRoot, segmentationName, meshSmoothingIterations, voxelSpacing );
+		this.meshCreator.setMeshCache( meshCache );
+	}
+
+	/**
+	 * Pre-render meshes for the given segments and persist them to disk.
+	 * This is an expensive, blocking operation — call from a background thread.
+	 *
+	 * @param segments  segments whose meshes should be computed and cached.
+	 */
+	public void preRenderSegments( Collection< S > segments )
+	{
+		if ( meshCache == null )
+		{
+			System.err.println( "[MoBIE] Mesh cache not configured; cannot pre-render." );
+			return;
+		}
+
+		for ( S segment : segments )
+		{
+			if ( segment.timePoint() != null && segment.timePoint() != currentTimePoint )
+				continue;
+
+			if ( meshCache.hasMesh( segment.label() ) )
+				continue;
+
+			try
+			{
+				final Source< AnnotationType< S > > source = getSource( segment );
+				// createSmoothCustomTriangleMesh will check the cache first,
+				// compute if missing, and store to cache afterwards
+				meshCreator.createSmoothCustomTriangleMesh( segment, voxelSpacing, false, source );
+			}
+			catch ( Exception e )
+			{
+				System.err.println( "[MoBIE] Could not pre-render mesh for segment " + segment.label() + ": " + e.getMessage() );
+			}
+		}
+
+		try
+		{
+			meshCache.flush();
+		}
+		catch ( IOException e )
+		{
+			System.err.println( "[MoBIE] Failed to flush mesh cache: " + e.getMessage() );
+		}
+	}
+
+	public MeshCache getMeshCache()
+	{
+		return meshCache;
 	}
 
 	private void updateSegmentColors()

--- a/src/main/java/org/embl/mobie/lib/volume/SegmentVolumeViewer.java
+++ b/src/main/java/org/embl/mobie/lib/volume/SegmentVolumeViewer.java
@@ -195,6 +195,18 @@ public class SegmentVolumeViewer< S extends Segment > implements ColoringListene
 	}
 
 	/**
+	 * Whether the given exception (or any of its causes) reports that a
+	 * segment has no voxels in the image volume at any resolution level.
+	 */
+	private static boolean noVoxelsInImage( final Throwable throwable )
+	{
+		for ( Throwable cause = throwable; cause != null; cause = cause.getCause() )
+			if ( cause.getMessage() != null && cause.getMessage().contains( "has no voxels in the image volume" ) )
+				return true;
+		return false;
+	}
+
+	/**
 	 * Pre-render meshes for the given segments and persist them to disk.
 	 * Segments are processed in parallel using the shared thread pool.
 	 *
@@ -226,6 +238,7 @@ public class SegmentVolumeViewer< S extends Segment > implements ColoringListene
 		final ArrayList< Future< ? > > futures = ThreadHelper.getFutures();
 		final AtomicInteger failures = new AtomicInteger( 0 );
 		final int maxLoggedFailures = 10;
+		final AtomicInteger noVoxelSegments = new AtomicInteger( 0 );
 
 		// Update the status bar on a time basis rather than on a fixed number
 		// of finished meshes, so that very fast and very slow segments both
@@ -249,12 +262,20 @@ public class SegmentVolumeViewer< S extends Segment > implements ColoringListene
 				}
 				catch ( Exception e )
 				{
-					final int failureCount = failures.incrementAndGet();
-					if ( failureCount <= maxLoggedFailures )
+					if ( noVoxelsInImage( e ) )
 					{
-						final Throwable cause = e.getCause();
-						IJ.log( "[MoBIE] Could not pre-render mesh for segment " + segment.label() + ": " + e.getMessage()
-								+ ( cause != null ? " (cause: " + cause.getMessage() + ")" : "" ) );
+						// benign: the label is absent from the volume at all levels
+						noVoxelSegments.incrementAndGet();
+					}
+					else
+					{
+						final int failureCount = failures.incrementAndGet();
+						if ( failureCount <= maxLoggedFailures )
+						{
+							final Throwable cause = e.getCause();
+							IJ.log( "[MoBIE] Could not pre-render mesh for segment " + segment.label() + ": " + e.getMessage()
+									+ ( cause != null ? " (cause: " + cause.getMessage() + ")" : "" ) );
+						}
 					}
 				}
 				finally
@@ -289,6 +310,9 @@ public class SegmentVolumeViewer< S extends Segment > implements ColoringListene
 
 		if ( failures.get() > 0 )
 			IJ.log( "[MoBIE] " + failures.get() + " of " + total + " meshes could not be pre-rendered." );
+
+		if ( noVoxelSegments.get() > 0 )
+			IJ.log( "[MoBIE] " + noVoxelSegments.get() + " segments have no voxels in the image volume at any resolution level and were skipped." );
 	}
 
 	public MeshCache getMeshCache()

--- a/src/main/java/org/embl/mobie/lib/volume/SegmentVolumeViewer.java
+++ b/src/main/java/org/embl/mobie/lib/volume/SegmentVolumeViewer.java
@@ -178,7 +178,7 @@ public class SegmentVolumeViewer< S extends Segment > implements ColoringListene
 			if ( bestSpacing == null )
 				return; // no cached resolution yet: auto resolution, no caching
 			voxelSpacing = new double[] { bestSpacing, bestSpacing, bestSpacing };
-			System.out.println( "[MoBIE] Using best available mesh cache resolution " + bestSpacing + " um for " + segmentationName );
+			IJ.log( "[MoBIE] Using best available mesh cache resolution " + bestSpacing + " um for " + segmentationName );
 		}
 
 		this.meshCache = new MeshCache( cacheRoot, segmentationName, meshSmoothingIterations, voxelSpacing );
@@ -195,7 +195,7 @@ public class SegmentVolumeViewer< S extends Segment > implements ColoringListene
 	{
 		if ( meshCache == null )
 		{
-			System.err.println( "[MoBIE] Mesh cache not configured; cannot pre-render." );
+			IJ.log( "[MoBIE] Mesh cache not configured; cannot pre-render." );
 			return;
 		}
 
@@ -223,7 +223,9 @@ public class SegmentVolumeViewer< S extends Segment > implements ColoringListene
 		// produce a steady ~10 s update cadence.
 		final long statusIntervalMillis = 10_000;
 		final AtomicLong lastStatusTimeMillis = new AtomicLong( System.currentTimeMillis() );
-		IJ.showStatus( "Pre-rendering meshes: 0/" + total );
+		final String initialStatus = "Pre-rendering meshes: 0/" + total;
+		IJ.showStatus( initialStatus );
+		IJ.log( initialStatus );
 
 		for ( S segment : pending )
 		{
@@ -242,7 +244,7 @@ public class SegmentVolumeViewer< S extends Segment > implements ColoringListene
 					if ( failureCount <= maxLoggedFailures )
 					{
 						final Throwable cause = e.getCause();
-						System.err.println( "[MoBIE] Could not pre-render mesh for segment " + segment.label() + ": " + e.getMessage()
+						IJ.log( "[MoBIE] Could not pre-render mesh for segment " + segment.label() + ": " + e.getMessage()
 								+ ( cause != null ? " (cause: " + cause.getMessage() + ")" : "" ) );
 					}
 				}
@@ -256,7 +258,11 @@ public class SegmentVolumeViewer< S extends Segment > implements ColoringListene
 					if ( done == total
 							|| ( now - lastStatusTime >= statusIntervalMillis
 									&& lastStatusTimeMillis.compareAndSet( lastStatusTime, now ) ) )
-						IJ.showStatus( "Pre-rendering meshes: " + done + "/" + total );
+					{
+						final String status = "Pre-rendering meshes: " + done + "/" + total;
+						IJ.showStatus( status );
+						IJ.log( status );
+					}
 				}
 			} ) );
 		}
@@ -269,11 +275,11 @@ public class SegmentVolumeViewer< S extends Segment > implements ColoringListene
 		}
 		catch ( IOException e )
 		{
-			System.err.println( "[MoBIE] Failed to flush mesh cache: " + e.getMessage() );
+			IJ.log( "[MoBIE] Failed to flush mesh cache: " + e.getMessage() );
 		}
 
 		if ( failures.get() > 0 )
-			System.err.println( "[MoBIE] " + failures.get() + " of " + total + " meshes could not be pre-rendered." );
+			IJ.log( "[MoBIE] " + failures.get() + " of " + total + " meshes could not be pre-rendered." );
 	}
 
 	public MeshCache getMeshCache()

--- a/src/main/java/org/embl/mobie/lib/volume/SegmentVolumeViewer.java
+++ b/src/main/java/org/embl/mobie/lib/volume/SegmentVolumeViewer.java
@@ -64,8 +64,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.embl.mobie.lib.util.ThreadHelper;
 
@@ -176,7 +174,7 @@ public class SegmentVolumeViewer< S extends Segment > implements ColoringListene
 		if ( voxelSpacing == null )
 		{
 			// Default to the finest resolution for which a cache already exists.
-			final Double bestSpacing = bestAvailableSpacing( cacheRoot, segmentationName, meshSmoothingIterations );
+			final Double bestSpacing = MeshCache.findFinestAvailableSpacing( cacheRoot, segmentationName, meshSmoothingIterations );
 			if ( bestSpacing == null )
 				return; // no cached resolution yet: auto resolution, no caching
 			voxelSpacing = new double[] { bestSpacing, bestSpacing, bestSpacing };
@@ -185,36 +183,6 @@ public class SegmentVolumeViewer< S extends Segment > implements ColoringListene
 
 		this.meshCache = new MeshCache( cacheRoot, segmentationName, meshSmoothingIterations, voxelSpacing );
 		this.meshCreator.setMeshCache( meshCache );
-	}
-
-	/**
-	 * Scan the cache directory for {@code <segmentationName>-sm<smoothing>-<spacing>um.mel}
-	 * files and return the smallest (finest) spacing found, or {@code null} if
-	 * no cache exists for this segmentation and smoothing level.
-	 */
-	private static Double bestAvailableSpacing( File cacheRoot, String segmentationName, int smoothingIterations )
-	{
-		if ( cacheRoot == null || !cacheRoot.isDirectory() )
-			return null;
-
-		final Pattern pattern = Pattern.compile(
-				Pattern.quote( segmentationName ) + "-sm" + smoothingIterations + "-([0-9_]+)um\\.mel" );
-
-		Double best = null;
-		final File[] files = cacheRoot.listFiles();
-		if ( files == null )
-			return null;
-
-		for ( final File file : files )
-		{
-			final Matcher matcher = pattern.matcher( file.getName() );
-			if ( !matcher.matches() )
-				continue;
-			final double spacing = Double.parseDouble( matcher.group( 1 ).replace( '_', '.' ) );
-			if ( best == null || spacing < best )
-				best = spacing;
-		}
-		return best;
 	}
 
 	/**

--- a/src/main/java/org/embl/mobie/lib/volume/SegmentVolumeViewer.java
+++ b/src/main/java/org/embl/mobie/lib/volume/SegmentVolumeViewer.java
@@ -319,6 +319,8 @@ public class SegmentVolumeViewer< S extends Segment > implements ColoringListene
 
 		new Thread( () ->
 		{
+			if ( universe == null )
+				return;
 			universe.setAutoAdjustView( true );
 			updateSelectedSegments( recomputeMeshes );
 			removeUnselectedSegments();
@@ -376,9 +378,12 @@ public class SegmentVolumeViewer< S extends Segment > implements ColoringListene
 	private synchronized void removeSegment( S segment )
 	{
 		final Content content = segmentToContent.get( segment );
-		universe.removeContent( content.getName() );
+		if ( content == null )
+			return;
 		segmentToContent.remove( segment );
 		contentToSegment.remove( content );
+		if ( universe != null )
+			universe.removeContent( content.getName() );
 	}
 
 	public synchronized void showSegments( boolean showSegments, boolean autoAdjustView )
@@ -431,9 +436,8 @@ public class SegmentVolumeViewer< S extends Segment > implements ColoringListene
 
 	private void removeSegments()
 	{
-		final Set< S > segments = selectionModel.getSelected();
-
-		for ( S segment : segments )
+		// remove whatever is currently displayed, not the (possibly larger) selection
+		for ( S segment : new HashSet<>( segmentToContent.keySet() ) )
 		{
 			removeSegment( segment );
 		}
@@ -468,6 +472,9 @@ public class SegmentVolumeViewer< S extends Segment > implements ColoringListene
 //
 //		for ( int j = 0; j < 10; j++ )
 //			System.out.println( ys[ ys.length - j - 1 ] );
+
+		if ( universe == null )
+			return;
 
 		final Bounds bounds = mesh.getBounds();
 		final Content content = universe.addCustomMesh( mesh, "" + segment.hashCode() );

--- a/src/main/java/org/embl/mobie/lib/volume/SegmentVolumeViewer.java
+++ b/src/main/java/org/embl/mobie/lib/volume/SegmentVolumeViewer.java
@@ -64,6 +64,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.embl.mobie.lib.util.ThreadHelper;
 
@@ -158,6 +160,12 @@ public class SegmentVolumeViewer< S extends Segment > implements ColoringListene
 	 * When set, mesh data is loaded from disk before computing and stored
 	 * to disk after computing.  Cached meshes are pre-smoothed, so loading
 	 * skips both marching cubes and smoothing.
+	 * <p>
+	 * If no fixed voxel spacing has been set (e.g. the view declares no
+	 * {@code resolution3d}), the best - i.e. finest - resolution for which a
+	 * mesh cache already exists for this segmentation is used automatically;
+	 * only if no cache exists at all is the cache left unconfigured (auto
+	 * resolution, no caching).
 	 *
 	 * @param segmentationName  human-readable name used in the cache file name
 	 * @param cacheRoot         root cache directory
@@ -166,10 +174,47 @@ public class SegmentVolumeViewer< S extends Segment > implements ColoringListene
 	public void configureMeshCache( String segmentationName, File cacheRoot )
 	{
 		if ( voxelSpacing == null )
-			return; // cannot cache without fixed voxel spacing
+		{
+			// Default to the finest resolution for which a cache already exists.
+			final Double bestSpacing = bestAvailableSpacing( cacheRoot, segmentationName, meshSmoothingIterations );
+			if ( bestSpacing == null )
+				return; // no cached resolution yet: auto resolution, no caching
+			voxelSpacing = new double[] { bestSpacing, bestSpacing, bestSpacing };
+			System.out.println( "[MoBIE] Using best available mesh cache resolution " + bestSpacing + " um for " + segmentationName );
+		}
 
 		this.meshCache = new MeshCache( cacheRoot, segmentationName, meshSmoothingIterations, voxelSpacing );
 		this.meshCreator.setMeshCache( meshCache );
+	}
+
+	/**
+	 * Scan the cache directory for {@code <segmentationName>-sm<smoothing>-<spacing>um.mel}
+	 * files and return the smallest (finest) spacing found, or {@code null} if
+	 * no cache exists for this segmentation and smoothing level.
+	 */
+	private static Double bestAvailableSpacing( File cacheRoot, String segmentationName, int smoothingIterations )
+	{
+		if ( cacheRoot == null || !cacheRoot.isDirectory() )
+			return null;
+
+		final Pattern pattern = Pattern.compile(
+				Pattern.quote( segmentationName ) + "-sm" + smoothingIterations + "-([0-9_]+)um\\.mel" );
+
+		Double best = null;
+		final File[] files = cacheRoot.listFiles();
+		if ( files == null )
+			return null;
+
+		for ( final File file : files )
+		{
+			final Matcher matcher = pattern.matcher( file.getName() );
+			if ( !matcher.matches() )
+				continue;
+			final double spacing = Double.parseDouble( matcher.group( 1 ).replace( '_', '.' ) );
+			if ( best == null || spacing < best )
+				best = spacing;
+		}
+		return best;
 	}
 
 	/**

--- a/src/main/java/org/embl/mobie/ui/UserInterfaceHelper.java
+++ b/src/main/java/org/embl/mobie/ui/UserInterfaceHelper.java
@@ -512,6 +512,8 @@ public class UserInterfaceHelper
 		{
 			// segments 3D view
 			panel.add( createSegmentsVolumeViewerVisibilityCheckbox( display ) );
+			// mesh pre-render
+			panel.add( createMeshPreRenderButton( display ) );
 			// BVV view
 			panel.add( createBVBVolumeVisibilityCheckbox( display, sourceAndConverters ) );
 			// table view
@@ -1036,6 +1038,52 @@ public class UserInterfaceHelper
 	private static Component createButtonPlaceholder()
 	{
 		return Box.createRigidArea( PREFERRED_BUTTON_SIZE );
+	}
+
+	private static JButton createMeshPreRenderButton( SegmentationDisplay display )
+	{
+		JButton button = new JButton( "M" );
+		button.setToolTipText( "Pre-render all segment meshes to disk cache" );
+		button.setPreferredSize( PREFERRED_CHECKBOX_SIZE );
+		button.setMargin( new java.awt.Insets( 0, 0, 0, 0 ) );
+
+		button.addActionListener( e -> new Thread( () ->
+		{
+			button.setEnabled( false );
+			button.setText( "..." );
+
+			try
+			{
+				final java.util.Collection segments;
+				if ( display.getAnnData() != null && display.getAnnData().getTable() != null )
+					segments = display.getAnnData().getTable().annotations();
+				else
+					segments = display.selectionModel.getSelected();
+
+				if ( segments.isEmpty() )
+				{
+					IJ.showMessage( "No segments to pre-render." );
+					return;
+				}
+
+				IJ.showStatus( "Pre-rendering " + segments.size() + " segment meshes..." );
+				display.segmentVolumeViewer.preRenderSegments( segments );
+				IJ.showStatus( "Pre-rendering complete. " + display.segmentVolumeViewer.getMeshCache().size() + " meshes cached." );
+			}
+			catch ( Exception ex )
+			{
+				IJ.showMessage( "Mesh pre-render failed: " + ex.getMessage() );
+			}
+			finally
+			{
+				SwingUtilities.invokeLater( () -> {
+					button.setText( "M" );
+					button.setEnabled( true );
+				} );
+			}
+		} ).start() );
+
+		return button;
 	}
 
 	private static Component createCheckboxPlaceholder()

--- a/src/test/java/org/embl/mobie/lib/volume/MeshCacheTest.java
+++ b/src/test/java/org/embl/mobie/lib/volume/MeshCacheTest.java
@@ -1,0 +1,157 @@
+/*-
+ * #%L
+ * Fiji viewer for MoBIE projects
+ * %%
+ * Copyright (C) 2018 - 2024 EMBL
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.embl.mobie.lib.volume;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link MeshCache}: round-tripping through the .mel file,
+ * appending across sessions, auto-persist when the in-memory map exceeds its
+ * threshold, and overwriting a previously persisted label.
+ */
+class MeshCacheTest
+{
+	@TempDir
+	File tempDir;
+
+	private MeshCache newCache( int persistThreshold )
+	{
+		return new MeshCache( tempDir, "test", 5, new double[] { 0.5 }, persistThreshold );
+	}
+
+	private static float[] randomMesh( Random rng, int numVertices )
+	{
+		final float[] vertices = new float[ numVertices * 3 ];
+		for ( int i = 0; i < vertices.length; i++ )
+			vertices[ i ] = rng.nextFloat() * 100.0f;
+		return vertices;
+	}
+
+	@Test
+	void storesFlushesAndReloads() throws IOException
+	{
+		final Random rng = new Random( 1 );
+		final float[] a = randomMesh( rng, 10 );
+		final float[] b = randomMesh( rng, 25 );
+
+		final MeshCache cache = newCache( 256 );
+		assertFalse( cache.hasMesh( 1 ) );
+		assertNull( cache.loadMesh( 1 ) );
+		cache.storeMesh( 1, a );
+		cache.storeMesh( 2, b );
+		assertEquals( 2, cache.size() );
+		assertArrayEquals( a, cache.loadMesh( 1 ) );
+		cache.flush();
+
+		final MeshCache reloaded = newCache( 256 );
+		assertTrue( reloaded.hasMesh( 1 ) );
+		assertTrue( reloaded.hasMesh( 2 ) );
+		assertArrayEquals( a, reloaded.loadMesh( 1 ) );
+		assertArrayEquals( b, reloaded.loadMesh( 2 ) );
+		assertEquals( 2, reloaded.size() );
+	}
+
+	@Test
+	void appendsAcrossInstances() throws IOException
+	{
+		final float[] a = randomMesh( new Random( 2 ), 7 );
+
+		final MeshCache first = newCache( 256 );
+		first.storeMesh( 1, a );
+		first.flush();
+
+		final MeshCache second = newCache( 256 );
+		assertTrue( second.hasMesh( 1 ) );
+		final float[] b = randomMesh( new Random( 3 ), 9 );
+		second.storeMesh( 2, b );
+		second.flush();
+
+		final MeshCache third = newCache( 256 );
+		assertArrayEquals( a, third.loadMesh( 1 ) );
+		assertArrayEquals( b, third.loadMesh( 2 ) );
+	}
+
+	@Test
+	void autoPersistsWhenThresholdExceeded()
+	{
+		final Random rng = new Random( 4 );
+		final int threshold = 5;
+		final MeshCache cache = newCache( threshold );
+
+		// Store far more than the threshold without ever calling flush():
+		// the cache must persist to disk on its own to stay memory-bounded,
+		// while still serving all stored meshes.
+		final java.util.Map< Long, float[] > expected = new java.util.HashMap<>();
+		for ( long label = 1; label <= 50; label++ )
+		{
+			final float[] mesh = randomMesh( rng, 3 + ( int ) ( label % 10 ) );
+			expected.put( label, mesh );
+			cache.storeMesh( label, mesh );
+		}
+		assertEquals( 50, cache.size() );
+		for ( long label = 1; label <= 50; label++ )
+			assertArrayEquals( expected.get( label ), cache.loadMesh( label ) );
+
+		// Everything must be readable back from disk alone.
+		final MeshCache reloaded = newCache( threshold );
+		assertEquals( 50, reloaded.size() );
+		for ( long label = 1; label <= 50; label++ )
+			assertArrayEquals( expected.get( label ), reloaded.loadMesh( label ) );
+	}
+
+	@Test
+	void overwritesPreviouslyPersistedLabel() throws IOException
+	{
+		final float[] v1 = randomMesh( new Random( 5 ), 4 );
+		final float[] v2 = randomMesh( new Random( 6 ), 12 );
+
+		final MeshCache first = newCache( 256 );
+		first.storeMesh( 1, v1 );
+		first.flush();
+
+		final MeshCache second = newCache( 256 );
+		second.storeMesh( 1, v2 ); // same label, updated mesh
+		assertArrayEquals( v2, second.loadMesh( 1 ) );
+		second.flush();
+
+		final MeshCache third = newCache( 256 );
+		assertArrayEquals( v2, third.loadMesh( 1 ) ); // latest wins
+	}
+}


### PR DESCRIPTION
Adds a persistent, disk-backed cache for the smoothed segment meshes shown in the Fiji 3D viewer, plus UI to build and reuse it. Works with any segmentation source — no dataset-specific code. I am using a custom file format for the cache file which is might not be ideal and to be discussed.

## What it does

- **`MeshCache`** (`~/.mobie/mesh-cache/<segmentation>-sm<k>-<spacing>um.mel`): binary per-segmentation cache of smoothed meshes. Memory-bounded: meshes are appended to the file whenever the in-memory buffer exceeds a threshold, and an on-disk index (label → offset) allows demand reads — so very large segment sets (e.g. tens of thousands of cells) can be pre-rendered without holding everything in RAM. Existing `.mel` format is versioned; nothing else changes on disk.
- **Pre-rendering** (`SegmentVolumeViewer.preRenderSegments`): computes + smooths meshes in parallel (shared thread pool), reports progress in the Fiji Log window and status bar (~10 s cadence), persists to disk, and continues gracefully past failures.
- **Resolution policy when no `resolution3d` is declared**: the finest resolution already present in the cache is used automatically. If no cache exists, a Log-window message explains that meshes will be computed on demand and how to pre-cache via the table's **Misc ▸ "Cache segment meshes…"**.
- **UI**: the segmentation table's Misc menu offers "Cache segment meshes...", with a dialog listing the segmentation's actual mipmap resolutions (µm) plus a custom spacing; defaults to the finest cached resolution.
- **Robustness**: if a segment has no voxels at the chosen mipmap level, extraction retries finer levels down to level 0; segments with no voxels at any level (e.g. table rows whose label is absent) are skipped and reported once, not as per-segment errors. Mesh-creation failures now keep their underlying cause.
- **Configurable cache location**: resolved by precedence — `-Dmobie.meshCacheDir` system property → `ij.Prefs` key `MoBIE.meshCacheDir` → portable default `<user.home>/.mobie/mesh-cache` (File-based, Windows-safe).

## Files

- New: `MeshCache`, `SegmentMeshCacher`, `MeshCacheTest`
- Modified: `SegmentVolumeViewer`, `MeshCreator`, `ViewManager`, `TableView`, `MoBIEHelper`, `UserInterfaceHelper`

## Validation

- `MeshCacheTest` (roundtrip, append across instances, auto-persist at small thresholds, overwrite of a cached label): green.
- Interactive runs validated in Fiji (Windows) on PlatyBrowser segmentation datasets (nuclei/cells/combined traces): caching at several resolutions, cache reuse on re-open, and the Log-window messages.